### PR TITLE
fix(landing): fix z-index and padding of main content

### DIFF
--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -25,7 +25,7 @@ export default function Home() {
   return (
     <div className="relative flex ">
       <div className="min-h-[100svh] flex items-center mx-auto w-full max-w-4xl">
-        <div className="flex flex-col gap-2 px-6 sm:px-0">
+        <div className="flex flex-col gap-2 px-6 z-30">
           {/* shadcn quote */}
           <Link
             href="https://x.com/shadcn/status/1949116870432338383"


### PR DESCRIPTION
## Problem
On tablet screens (640px or higher), horizontal padding no longer works, and content is wrapped around the edge of the screen. In addition, the right-hand content is now positioned below the absolutely positioned gradient background.

<img width="692" height="791" alt="evidence" src="https://github.com/user-attachments/assets/27b7102d-2bac-4081-b013-ea0ea4fc2f64" />

## Solution
I remove `sm:px-0` and add `z-20` to the main container.

<img width="699" height="747" alt="image" src="https://github.com/user-attachments/assets/ab7a2162-7348-4724-9ae3-425d4e9a9578" />

## Testing

- [x] Tested on mobile viewport
- [x] Sidebar closes after menu item click
- [x] Navigation works correctly
- [x] No impact on desktop behavior