### PR TITLE
fixed code theme for light mode and dark mode

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -189,3 +189,12 @@ pre {
 code {
   font-family: var(--font-jetbrains-mono), monospace;
 }
+
+
+code span {
+  color: var(--shiki-light) !important;
+}
+
+.dark code span {
+  color: var(--shiki-dark) !important;
+}

--- a/components/ui/code-block/code-block-html.tsx
+++ b/components/ui/code-block/code-block-html.tsx
@@ -12,7 +12,7 @@ const CodeBlockHtml = ({
     <div className="relative rounded-[14px]">
       <div
         className={cn(
-          "text-sm rounded-b-[14px] duration-300 dark:[&_pre]:!bg-white/7 [&_pre]:!bg-white overflow-hidden"
+          "text-sm rounded-b-[14px] duration-300 dark:[&_pre]:!bg-white/4 [&_pre]:!bg-white overflow-hidden [&_code]:font-mono [&_code]:text-[14px] [&_pre]:overflow-auto [&_pre]:rounded-md  [&_pre]:p-4 [&_pre]:leading-snug "
         )}
       >
         <div

--- a/components/ui/code-block/code-block.tsx
+++ b/components/ui/code-block/code-block.tsx
@@ -16,7 +16,9 @@ interface CodeBlockProps {
   heightAuto?: boolean;
 }
 
-// Server Component (async) - for use in server-side pages
+// -------------------
+// Server Component
+// -------------------
 const CodeBlock = async ({
   language,
   code,
@@ -26,11 +28,15 @@ const CodeBlock = async ({
 }: CodeBlockProps) => {
   const html = await codeToHtml(code, {
     lang: language,
-    theme: "one-dark-pro",
+    themes: {
+      light: "min-light",
+      dark: "vesper",
+    },
+    defaultColor: false,
   });
 
   return (
-    <div className="bg-border/40 p-1 rounded-[14px] group dark:shadow-md ">
+    <div className="bg-border/40 p-1 rounded-[14px] group dark:shadow-md">
       <div className="pb-2 py-1 px-3 flex items-center justify-between">
         <div className="flex items-center gap-2">
           {getCodeBlockIcon(type)}
@@ -45,7 +51,9 @@ const CodeBlock = async ({
   );
 };
 
-// Client Component (non-async) - for use in client components with pre-generated HTML
+// -------------------
+// Client Component
+// -------------------
 interface CodeBlockClientProps {
   html: string;
   code: string;
@@ -78,22 +86,35 @@ const CodeBlockClient = ({
   );
 };
 
-const AddShadcnCodeBlock = ({ text }: { text: string }) => {
+// -------------------
+// AddShadcnCodeBlock
+// -------------------
+const AddShadcnCodeBlock = async ({ text }: { text: string }) => {
+  const html = await codeToHtml(text, {
+    lang: "bash",
+    themes: {
+      light: "min-light",
+      dark: "vesper",
+    },
+    defaultColor: false,
+  });
+
   return (
     <div className="bg-border/40 p-1 rounded-[14px] group dark:shadow-md flex flex-col">
-      <div className="flex justify-between px-3 py-1 items-center">
+      <div className="flex justify-between px-3 py-2 items-center">
         <span className="text-xs text-muted-foreground">Command</span>
         <CopyButton code={text} />
       </div>
-      <span className="p-3 text-sm bg-white dark:bg-[#27272A] rounded-xl font-medium text-secondary-foreground">
-        {text}
-      </span>
+      <CodeBlockHtml html={html} heightAuto />
     </div>
   );
 };
 
 export { CodeBlock, CodeBlockClient, AddShadcnCodeBlock };
 
+// -------------------
+// Icon helper
+// -------------------
 const getCodeBlockIcon = (type: CodeBlockType) => {
   switch (type) {
     case "code":


### PR DESCRIPTION
Fixed code theme issue 

Dark Before 
<img width="1234" height="829" alt="Screenshot 2025-08-23 at 11 52 04 PM" src="https://github.com/user-attachments/assets/9defb6be-7d39-48fa-a95e-ed48a328be17" />

Dark After ✨
<img width="1208" height="825" alt="Screenshot 2025-08-23 at 11 52 43 PM" src="https://github.com/user-attachments/assets/8d749a43-35e7-4923-a792-2fe342aafbe1" />

Light Before 
<img width="1146" height="828" alt="Screenshot 2025-08-23 at 11 53 07 PM" src="https://github.com/user-attachments/assets/f7a95255-e862-47a5-b8c7-4f9e3886e2e8" />

Light After 🔥
<img width="1220" height="838" alt="Screenshot 2025-08-23 at 11 52 54 PM" src="https://github.com/user-attachments/assets/3b478734-fd06-4b45-b2fc-4d27b7ac89ea" />

