### PR TITLE
[Fix] Card title layout shift

### DIFF
--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -32,7 +32,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-title"
-      className={cn("leading-none font-semibold", className)}
+      className={cn("leading-none font-semibold tabular-nums", className)}
       {...props}
     />
   );


### PR DESCRIPTION
This adds `tabular-nums` to the `CardTitle` component to prevent the badge component from bouncing around when animations are triggered that impact the title.

Before:

https://github.com/user-attachments/assets/1066bb00-8407-452a-a2db-1d09dc5a9a55

After:

https://github.com/user-attachments/assets/02ab2a0d-2559-479b-8c43-ad29eda10d24

Now, there's a smooth change in numbers without the badge moving.
