### PR TITLE
feat: add extrema downsampling helper

### DIFF
--- a/src/content/docs/line-chart/static.mdx
+++ b/src/content/docs/line-chart/static.mdx
@@ -166,6 +166,18 @@ Add `isClickable` to any `<Line>` (and to `<Legend>`) to make those series selec
   </AlertContent>
 </Alert>
 
+### Dense Data
+
+For long time ranges, render a smaller data set with `downsampleExtrema` before passing it to the chart. Unlike average-based downsampling, this keeps the first row, last row, minimum row, and maximum row from each bucket, so short spikes and dips remain visible while the SVG stays light enough to animate smoothly.
+
+```tsx
+import { downsampleExtrema } from "@/components/evilcharts/ui/chart";
+
+const visibleData = downsampleExtrema(data, 500, ["desktop", "mobile"]);
+```
+
+Use a lower target for compact previews and sparklines, and a higher target when the chart has enough room or when preserving short-lived peaks is more important than reducing visual density.
+
 ## Examples
 
 Below are some examples of the line chart with different `variants`. where you can change the `curveType` & `strokeVariant`. 

--- a/src/registry/ui/chart.tsx
+++ b/src/registry/ui/chart.tsx
@@ -252,6 +252,49 @@ export const getLoadingData = (points: number = 10, min: number = 0, max: number
   }));
 };
 
+export function downsampleExtrema<TData extends Record<string, unknown>>(
+  rows: TData[],
+  targetCount: number,
+  valueKeys: (keyof TData & string)[],
+): TData[] {
+  if (targetCount <= 0) return [];
+  if (rows.length <= targetCount) return rows;
+
+  const bucketSize = Math.ceil(rows.length / targetCount);
+  const sampled: TData[] = [];
+
+  for (let startIndex = 0; startIndex < rows.length; startIndex += bucketSize) {
+    const bucket = rows.slice(startIndex, startIndex + bucketSize);
+    const picks = new Map<number, TData>();
+    const add = (row: TData | undefined, rowIndex: number) => {
+      if (row) picks.set(rowIndex, row);
+    };
+
+    add(bucket[0], startIndex);
+    add(bucket[bucket.length - 1], startIndex + bucket.length - 1);
+
+    valueKeys.forEach((key) => {
+      const valid = bucket
+        .map((row, offset) => ({
+          row,
+          rowIndex: startIndex + offset,
+          value: Number(row[key]),
+        }))
+        .filter((item) => Number.isFinite(item.value));
+
+      if (!valid.length) return;
+      const min = valid.reduce((best, item) => (item.value < best.value ? item : best), valid[0]);
+      const max = valid.reduce((best, item) => (item.value > best.value ? item : best), valid[0]);
+      add(min.row, min.rowIndex);
+      add(max.row, max.rowIndex);
+    });
+
+    sampled.push(...[...picks.entries()].sort(([a], [b]) => a - b).map(([, row]) => row));
+  }
+
+  return sampled;
+}
+
 export {
   ChartContainer,
   ChartStyle,


### PR DESCRIPTION
## Summary

- add a `downsampleExtrema` helper for dense chart data
- preserve the first row, last row, minimum row, and maximum row from each bucket
- document dense time-series usage in the static line chart docs

## Benefits

Average-based downsampling can hide short spikes and dips. Extrema-preserving downsampling keeps important peaks visible while reducing the SVG point count enough for smoother rendering, hover, and brush interactions.

## Real-world measurement

In a home air-quality dashboard using long-range Awair humidity data, a 12-month view had 25,974 records and 8,658 aligned chart rows. With extrema-preserving sampling targets, the main chart went from 1,969 rendered rows to 1,068 rows, and the brush overview went from 8,658 rows to 685 rows, while still preserving the visible peaks and lows that average smoothing had hidden.

## Notes

- No runtime dependency changes
- The helper returns the original rows when the input is already under the target
- Output can include more than `targetCount` rows because each bucket may keep multiple important points
