### PR TITLE
docs: add Brush pages for recharts and echarts providers

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -551,6 +551,19 @@
       ]
     },
     {
+      "name": "ex-brush-echarts-area-chart",
+      "registryDependencies": [
+        "@evilcharts/echarts-area-chart"
+      ],
+      "type": "registry:block",
+      "files": [
+        {
+          "path": "src/registry/examples/echarts/ex-brush-echarts-area-chart.tsx",
+          "type": "registry:block"
+        }
+      ]
+    },
+    {
       "name": "ex-buffer-echarts-area-chart",
       "registryDependencies": [
         "@evilcharts/echarts-area-chart"
@@ -1937,6 +1950,19 @@
       "files": [
         {
           "path": "src/registry/examples/recharts/ex-area-chart.tsx",
+          "type": "registry:block"
+        }
+      ]
+    },
+    {
+      "name": "ex-brush-area-chart",
+      "registryDependencies": [
+        "@evilcharts/recharts-area-chart"
+      ],
+      "type": "registry:block",
+      "files": [
+        {
+          "path": "src/registry/examples/recharts/ex-brush-area-chart.tsx",
           "type": "registry:block"
         }
       ]

--- a/src/assets/icons/index.tsx
+++ b/src/assets/icons/index.tsx
@@ -1193,6 +1193,57 @@ export function DotsIcon({
   );
 }
 
+export function BrushIcon({
+  fill = "currentColor",
+  secondaryfill,
+  width = "1em",
+  height = "1em",
+  ...props
+}: IconProps) {
+  secondaryfill = secondaryfill || fill;
+
+  return (
+    <svg
+      height={height}
+      width={width}
+      viewBox="0 0 18 18"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <g fill={fill}>
+        <rect
+          height="10"
+          width="3.5"
+          fill={secondaryfill}
+          fillOpacity="0.4"
+          rx="1.25"
+          x="1"
+          y="4"
+        />
+        <rect
+          height="10"
+          width="3.5"
+          fill={secondaryfill}
+          fillOpacity="0.4"
+          rx="1.25"
+          x="13.5"
+          y="4"
+        />
+        <rect
+          height="10"
+          width="6"
+          fill="none"
+          rx="1.5"
+          stroke={fill}
+          strokeWidth="2"
+          x="6"
+          y="4"
+        />
+      </g>
+    </svg>
+  );
+}
+
 export function ChartLegendIcon({
   fill = "currentColor",
   secondaryfill,

--- a/src/content/docs/echarts/meta.json
+++ b/src/content/docs/echarts/meta.json
@@ -13,6 +13,7 @@
     "sankey-chart",
     "ui/tooltip",
     "ui/legend",
-    "ui/dots"
+    "ui/dots",
+    "ui/brush"
   ]
 }

--- a/src/content/docs/echarts/ui/brush.mdx
+++ b/src/content/docs/echarts/ui/brush.mdx
@@ -1,0 +1,98 @@
+---
+title: Brush
+description: A zoom brush that filters the chart down to a draggable range of the data.
+image: /og/og-image.png
+---
+
+## Usage
+
+Add `<EChartsAreaChart.Brush />` as a child of the chart root. Its presence renders the brush footer — a miniature of the **full** dataset with a draggable selection window over it. Narrowing that window filters the main chart to the selected range; the miniature always keeps showing everything, so you never lose your place.
+
+Set `xDataKey` on the root (or `dataKey` on `<XAxis />`) so the handles can label themselves with the category under each edge.
+
+```tsx
+import { EChartsAreaChart } from "@/components/evilcharts/charts/echarts-area-chart";
+
+<EChartsAreaChart data={data} config={chartConfig} xDataKey="date">
+  <EChartsAreaChart.XAxis dataKey="date" />
+  <EChartsAreaChart.Brush formatLabel={(value) => String(value)} />
+  <EChartsAreaChart.Area dataKey="desktop" variant="gradient" />
+</EChartsAreaChart>;
+```
+
+## Example
+
+<ComponentPreview className="mb-0" title="<EChartsAreaChart.Brush />" name="ex-brush-echarts-area-chart" />
+
+<Alert>
+  <AlertContent>
+    Drag either handle to resize the range, or drag the selected region itself to pan without
+    changing its width. Handle labels fade in while the pointer is over the brush. Because the
+    ECharts brush is backed by a native `dataZoom`, the main plot is draggable too — drag the chart
+    itself to slide the visible window, and the brush follows along.
+  </AlertContent>
+</Alert>
+
+## Supported Charts
+
+The brush is available on the cartesian charts — `EChartsAreaChart`, `EChartsLineChart`, `EChartsBarChart`, and `EChartsComposedChart`. Attach it exactly the same way on each:
+
+```tsx
+<EChartsLineChart.Brush />
+<EChartsBarChart.Brush />
+<EChartsComposedChart.Brush />
+```
+
+The miniature mirrors the chart it belongs to. Area and composed charts draw filled areas, line charts draw strokes only, and bar charts draw rounded bars — and it inherits the parent chart's stacking and series colors, dimming alongside the main plot when a series is selected.
+
+The brush is hidden while the chart is in its loading state, and it never renders for the non-cartesian charts (pie, radar, radial, sankey), which have no continuous axis to zoom.
+
+## Reacting to the Range
+
+Filtering the chart is automatic. Pass `onChange` when something *outside* the chart needs to follow along, such as a heading that reports the visible window:
+
+```tsx
+const [range, setRange] = useState({ startIndex: 0, endIndex: data.length - 1 });
+
+<EChartsAreaChart data={data} config={chartConfig} xDataKey="date">
+  <EChartsAreaChart.Brush onChange={setRange} />
+  <EChartsAreaChart.Area dataKey="desktop" variant="gradient" />
+</EChartsAreaChart>;
+
+// data[range.startIndex].date → data[range.endIndex].date
+```
+
+`onChange` fires with data **indices**, not values, so look the labels up on your own rows.
+
+## How It Differs from Recharts
+
+Same JSX, same props, same behavior — but ECharts renders to a `<canvas>`, so the brush is built differently underneath. The miniature is a real second ECharts grid holding mirrored copies of every series. A fully transparent native `dataZoom` slider sits on top of it and supplies the drag interaction, while everything you actually see — the rounded selection frame, the dimmed sides, the grip-dot handle pills, and the range labels — is drawn as canvas elements that track the selection directly.
+
+The practical differences: the main plot gains drag-to-pan for free, and the footer is a close reconstruction of the Recharts `EvilBrush` rather than a pixel-identical copy of it.
+
+## API Reference
+
+<ApiHeading>Brush</ApiHeading>
+
+Composed as a child of the chart root. It renders nothing itself — its presence turns the brush footer on, and its props configure it.
+
+<ApiTable>
+  <ApiRow name="height" type="number" default="56">
+    Height of the brush preview strip in pixels.
+  </ApiRow>
+  <ApiRow name="formatLabel" type="(value: string, index: number) => string">
+    Formats the range-handle labels from the category under each edge. Defaults to the raw value.
+  </ApiRow>
+  <ApiRow name="onChange" type="(range: { startIndex: number; endIndex: number }) => void">
+    Fires as the selection moves, with the inclusive data indices of the visible range.
+  </ApiRow>
+</ApiTable>
+
+<ApiHeading>Root</ApiHeading>
+
+<ApiTable>
+  <ApiRow name="xDataKey" type="string">
+    The data key the handle labels read from. Falls back to the `<XAxis />` `dataKey`, then to the
+    first data column no series has claimed.
+  </ApiRow>
+</ApiTable>

--- a/src/content/docs/recharts/meta.json
+++ b/src/content/docs/recharts/meta.json
@@ -14,6 +14,7 @@
     "ui/background",
     "ui/tooltip",
     "ui/legend",
-    "ui/dots"
+    "ui/dots",
+    "ui/brush"
   ]
 }

--- a/src/content/docs/recharts/ui/brush.mdx
+++ b/src/content/docs/recharts/ui/brush.mdx
@@ -1,0 +1,91 @@
+---
+title: Brush
+description: A zoom brush that filters the chart down to a draggable range of the data.
+image: /og/og-image.png
+---
+
+## Usage
+
+Add `<EvilAreaChart.Brush />` as a child of the chart root. Its presence renders the brush footer — a miniature of the **full** dataset with a draggable selection window over it. Narrowing that window filters the main chart to the selected range; the miniature always keeps showing everything, so you never lose your place.
+
+Set `xDataKey` on the root so the handles can label themselves with the value under each edge.
+
+```tsx
+import { EvilAreaChart } from "@/components/evilcharts/charts/recharts-area-chart";
+
+<EvilAreaChart data={data} config={chartConfig} xDataKey="date">
+  <EvilAreaChart.XAxis dataKey="date" />
+  <EvilAreaChart.Brush formatLabel={(value) => String(value)} />
+  <EvilAreaChart.Area dataKey="desktop" variant="gradient" />
+</EvilAreaChart>;
+```
+
+## Example
+
+<ComponentPreview className="mb-0" title="<EvilAreaChart.Brush />" name="ex-brush-area-chart" />
+
+<Alert>
+  <AlertContent>
+    Drag either handle to resize the range, or drag the selected region itself to pan without
+    changing its width. Handle labels fade in while the pointer is over the brush. Dragging is
+    pointer-based, so mouse, touch, and pen all work.
+  </AlertContent>
+</Alert>
+
+## Supported Charts
+
+The brush is available on the cartesian charts — `EvilAreaChart`, `EvilLineChart`, `EvilBarChart`, and `EvilComposedChart`. Attach it exactly the same way on each:
+
+```tsx
+<EvilLineChart.Brush />
+<EvilBarChart.Brush />
+<EvilComposedChart.Brush />
+```
+
+The miniature mirrors the chart it belongs to. Area and composed charts draw filled areas, line charts draw strokes only, and bar charts draw rounded bars — and it inherits the parent chart's `curveType`, stacking, bar radius, and series colors, so the footer always reads as the same chart in small.
+
+The brush is hidden while the chart is in its loading state, and it never renders for the non-cartesian charts (pie, radar, radial, sankey), which have no continuous axis to zoom.
+
+## Reacting to the Range
+
+Filtering the chart is automatic — the root already slices its data to the selection. Pass `onChange` when something *outside* the chart needs to follow along, such as a heading that reports the visible window:
+
+```tsx
+const [range, setRange] = useState({ startIndex: 0, endIndex: data.length - 1 });
+
+<EvilAreaChart data={data} config={chartConfig} xDataKey="date">
+  <EvilAreaChart.Brush onChange={setRange} />
+  <EvilAreaChart.Area dataKey="desktop" variant="gradient" />
+</EvilAreaChart>;
+
+// data[range.startIndex].date → data[range.endIndex].date
+```
+
+`onChange` fires with data **indices**, not values, so look the labels up on your own rows.
+
+## API Reference
+
+<ApiHeading>Brush</ApiHeading>
+
+Composed as a child of the chart root. It renders nothing itself — its presence turns the brush footer on, and its props configure it.
+
+<ApiTable>
+  <ApiRow name="height" type="number" default="56">
+    Height of the brush preview strip in pixels.
+  </ApiRow>
+  <ApiRow name="formatLabel" type="(value: unknown, index: number) => string">
+    Formats the range-handle labels from the `xDataKey` value under each edge. Defaults to the raw
+    value.
+  </ApiRow>
+  <ApiRow name="onChange" type="(range: { startIndex: number; endIndex: number }) => void">
+    Fires as the selection moves, with the inclusive data indices of the visible range.
+  </ApiRow>
+</ApiTable>
+
+<ApiHeading>Root</ApiHeading>
+
+<ApiTable>
+  <ApiRow name="xDataKey" type="string">
+    The data key the handle labels read from. Without it the handles fall back to raw indices.
+  </ApiRow>
+</ApiTable>

--- a/src/globals/constants/docs-sidebar.tsx
+++ b/src/globals/constants/docs-sidebar.tsx
@@ -1,5 +1,6 @@
 import {
   BackgroundIcon,
+  BrushIcon,
   ChartConfigIcon,
   ChartLegendIcon,
   DotsIcon,
@@ -64,6 +65,11 @@ export function getChartComponentOptions(provider: Provider): SidebarOption[] {
       name: "Dots",
       url: `/docs/${provider}/ui/dots`,
       icon: <DotsIcon />,
+    },
+    {
+      name: "Brush",
+      url: `/docs/${provider}/ui/brush`,
+      icon: <BrushIcon />,
     },
   ];
 }

--- a/src/registry/__index__.tsx
+++ b/src/registry/__index__.tsx
@@ -529,6 +529,24 @@ export const Index: Record<string, any> = {
     categories: undefined,
     meta: undefined,
   },
+  "ex-brush-echarts-area-chart": {
+    name: "ex-brush-echarts-area-chart",
+    description: "",
+    type: "registry:block",
+    registryDependencies: ["@evilcharts/echarts-area-chart"],
+    files: [{
+      path: "@/registry/examples/echarts/ex-brush-echarts-area-chart.tsx",
+      type: "registry:block",
+      target: ""
+    }],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/examples/echarts/ex-brush-echarts-area-chart.tsx")
+      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: undefined,
+    meta: undefined,
+  },
   "ex-buffer-echarts-area-chart": {
     name: "ex-buffer-echarts-area-chart",
     description: "",
@@ -2449,6 +2467,24 @@ export const Index: Record<string, any> = {
     }],
     component: React.lazy(async () => {
       const mod = await import("@/registry/examples/recharts/ex-area-chart.tsx")
+      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: undefined,
+    meta: undefined,
+  },
+  "ex-brush-area-chart": {
+    name: "ex-brush-area-chart",
+    description: "",
+    type: "registry:block",
+    registryDependencies: ["@evilcharts/recharts-area-chart"],
+    files: [{
+      path: "@/registry/examples/recharts/ex-brush-area-chart.tsx",
+      type: "registry:block",
+      target: ""
+    }],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/examples/recharts/ex-brush-area-chart.tsx")
       const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
       return { default: mod.default || mod[exportName] }
     }),

--- a/src/registry/examples/echarts/ex-brush-echarts-area-chart.tsx
+++ b/src/registry/examples/echarts/ex-brush-echarts-area-chart.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { EChartsAreaChart, type ChartConfig } from "@/registry/charts/echarts-area-chart";
+
+const data = [
+  { date: "June 1", desktop: 412, mobile: 268 },
+  { date: "June 2", desktop: 468, mobile: 301 },
+  { date: "June 3", desktop: 501, mobile: 334 },
+  { date: "June 4", desktop: 486, mobile: 312 },
+  { date: "June 5", desktop: 523, mobile: 349 },
+  { date: "June 6", desktop: 297, mobile: 198 },
+  { date: "June 7", desktop: 264, mobile: 173 },
+  { date: "June 8", desktop: 534, mobile: 356 },
+  { date: "June 9", desktop: 578, mobile: 384 },
+  { date: "June 10", desktop: 612, mobile: 402 },
+  { date: "June 11", desktop: 596, mobile: 391 },
+  { date: "June 12", desktop: 641, mobile: 428 },
+  { date: "June 13", desktop: 351, mobile: 236 },
+  { date: "June 14", desktop: 318, mobile: 211 },
+  { date: "June 15", desktop: 663, mobile: 441 },
+  { date: "June 16", desktop: 702, mobile: 467 },
+  { date: "June 17", desktop: 688, mobile: 452 },
+  { date: "June 18", desktop: 731, mobile: 489 },
+  { date: "June 19", desktop: 754, mobile: 503 },
+  { date: "June 20", desktop: 402, mobile: 271 },
+  { date: "June 21", desktop: 376, mobile: 249 },
+  { date: "June 22", desktop: 769, mobile: 512 },
+  { date: "June 23", desktop: 812, mobile: 538 },
+  { date: "June 24", desktop: 798, mobile: 524 },
+  { date: "June 25", desktop: 843, mobile: 561 },
+  { date: "June 26", desktop: 867, mobile: 579 },
+  { date: "June 27", desktop: 451, mobile: 302 },
+  { date: "June 28", desktop: 428, mobile: 287 },
+  { date: "June 29", desktop: 881, mobile: 594 },
+  { date: "June 30", desktop: 926, mobile: 618 },
+];
+
+const chartConfig = {
+  desktop: {
+    label: "Desktop",
+    colors: {
+      light: ["#047857"],
+      dark: ["#10b981"],
+    },
+  },
+  mobile: {
+    label: "Mobile",
+    colors: {
+      light: ["#be123c"],
+      dark: ["#f43f5e"],
+    },
+  },
+} satisfies ChartConfig;
+
+export function EChartsExampleBrushAreaChart() {
+  return (
+    <EChartsAreaChart
+      data={data}
+      config={chartConfig}
+      className="h-full w-full p-4"
+      curveType="monotone"
+      xDataKey="date"
+    >
+      <EChartsAreaChart.Grid />
+      <EChartsAreaChart.XAxis dataKey="date" tickFormatter={(value) => value.split(" ")[1]} />
+      <EChartsAreaChart.Brush
+        height={56} // [!code highlight]
+        formatLabel={(value) => String(value)} // [!code highlight]
+      />
+      <EChartsAreaChart.Legend isClickable />
+      <EChartsAreaChart.Tooltip />
+      <EChartsAreaChart.Area dataKey="desktop" variant="gradient" isClickable />
+      <EChartsAreaChart.Area dataKey="mobile" variant="gradient" isClickable />
+    </EChartsAreaChart>
+  );
+}

--- a/src/registry/examples/recharts/ex-brush-area-chart.tsx
+++ b/src/registry/examples/recharts/ex-brush-area-chart.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { EvilAreaChart } from "@/registry/charts/recharts-area-chart";
+import { type ChartConfig } from "@/registry/ui/recharts-chart";
+
+const data = [
+  { date: "June 1", desktop: 412, mobile: 268 },
+  { date: "June 2", desktop: 468, mobile: 301 },
+  { date: "June 3", desktop: 501, mobile: 334 },
+  { date: "June 4", desktop: 486, mobile: 312 },
+  { date: "June 5", desktop: 523, mobile: 349 },
+  { date: "June 6", desktop: 297, mobile: 198 },
+  { date: "June 7", desktop: 264, mobile: 173 },
+  { date: "June 8", desktop: 534, mobile: 356 },
+  { date: "June 9", desktop: 578, mobile: 384 },
+  { date: "June 10", desktop: 612, mobile: 402 },
+  { date: "June 11", desktop: 596, mobile: 391 },
+  { date: "June 12", desktop: 641, mobile: 428 },
+  { date: "June 13", desktop: 351, mobile: 236 },
+  { date: "June 14", desktop: 318, mobile: 211 },
+  { date: "June 15", desktop: 663, mobile: 441 },
+  { date: "June 16", desktop: 702, mobile: 467 },
+  { date: "June 17", desktop: 688, mobile: 452 },
+  { date: "June 18", desktop: 731, mobile: 489 },
+  { date: "June 19", desktop: 754, mobile: 503 },
+  { date: "June 20", desktop: 402, mobile: 271 },
+  { date: "June 21", desktop: 376, mobile: 249 },
+  { date: "June 22", desktop: 769, mobile: 512 },
+  { date: "June 23", desktop: 812, mobile: 538 },
+  { date: "June 24", desktop: 798, mobile: 524 },
+  { date: "June 25", desktop: 843, mobile: 561 },
+  { date: "June 26", desktop: 867, mobile: 579 },
+  { date: "June 27", desktop: 451, mobile: 302 },
+  { date: "June 28", desktop: 428, mobile: 287 },
+  { date: "June 29", desktop: 881, mobile: 594 },
+  { date: "June 30", desktop: 926, mobile: 618 },
+];
+
+const chartConfig = {
+  desktop: {
+    label: "Desktop",
+    colors: {
+      light: ["#047857"],
+      dark: ["#10b981"],
+    },
+  },
+  mobile: {
+    label: "Mobile",
+    colors: {
+      light: ["#be123c"],
+      dark: ["#f43f5e"],
+    },
+  },
+} satisfies ChartConfig;
+
+export function EvilExampleBrushAreaChart() {
+  return (
+    <EvilAreaChart
+      data={data}
+      config={chartConfig}
+      className="h-full w-full p-4"
+      curveType="monotone"
+      xDataKey="date"
+    >
+      <EvilAreaChart.Grid />
+      <EvilAreaChart.XAxis dataKey="date" tickFormatter={(value) => value.split(" ")[1]} />
+      <EvilAreaChart.Brush
+        height={56} // [!code highlight]
+        formatLabel={(value) => String(value)} // [!code highlight]
+      />
+      <EvilAreaChart.Legend isClickable />
+      <EvilAreaChart.Tooltip />
+      <EvilAreaChart.Area dataKey="desktop" variant="gradient" isClickable />
+      <EvilAreaChart.Area dataKey="mobile" variant="gradient" isClickable />
+    </EvilAreaChart>
+  );
+}

--- a/src/registry/registry-example.ts
+++ b/src/registry/registry-example.ts
@@ -25,6 +25,17 @@ export const examples: Registry["items"] = [
     ],
   },
   {
+    name: "ex-brush-echarts-area-chart",
+    registryDependencies: ["@evilcharts/echarts-area-chart"],
+    type: "registry:block",
+    files: [
+      {
+        path: "examples/echarts/ex-brush-echarts-area-chart.tsx",
+        type: "registry:block",
+      },
+    ],
+  },
+  {
     name: "ex-buffer-echarts-area-chart",
     registryDependencies: ["@evilcharts/echarts-area-chart"],
     type: "registry:block",
@@ -1205,6 +1216,17 @@ export const examples: Registry["items"] = [
     files: [
       {
         path: "examples/recharts/ex-area-chart.tsx",
+        type: "registry:block",
+      },
+    ],
+  },
+  {
+    name: "ex-brush-area-chart",
+    registryDependencies: ["@evilcharts/recharts-area-chart"],
+    type: "registry:block",
+    files: [
+      {
+        path: "examples/recharts/ex-brush-area-chart.tsx",
         type: "registry:block",
       },
     ],


### PR DESCRIPTION
## What

The zoom brush had **no dedicated docs page** on either provider. It existed only as an `<ApiHeading>` block buried inside each cartesian chart's `static.mdx`, so there was nowhere to link someone who asked "how do I add a brush?".

This adds a `Brush` page under **Chart Components** for both providers, each with a working preview.

## Changes

**Docs**
- `src/content/docs/recharts/ui/brush.mdx` — usage, supported charts, an `onChange` recipe, per-part API reference
- `src/content/docs/echarts/ui/brush.mdx` — same shape, plus a *How It Differs from Recharts* section covering the canvas implementation (mirrored second grid + transparent native `dataZoom` for drag + zrender overlays for the visible chrome)

**Examples** (one per provider, area chart as the base)
- `ex-brush-area-chart` / `ex-brush-echarts-area-chart` — 30 daily points so narrowing the range actually reads. The axis shows bare day numbers while the brush handles show the full `"June 12"` label, demonstrating that `formatLabel` is separate from the axis `tickFormatter`.

**Wiring**
- both examples registered in `registry-example.ts`; `"ui/brush"` added to each provider's `meta.json`
- new `BrushIcon` + an entry in `getChartComponentOptions`
- `registry.json` / `__index__.tsx` regenerated via `registry:fresh`

## Notes for review

**The sidebar needed more than `meta.json`.** The "Chart Components" group is a hand-written list in `docs-sidebar.tsx`, not derived from the page tree — `NavMain` only renders tree items of `type === "folder"`, and listing `ui/brush` in `pages` flattens it to a `page` at the provider level. Without the constant *and* an icon, the page was reachable by URL but invisible in the nav. Worth knowing for the next `ui/*` page; `.contexts/echarts-provider.md` §3 currently says the sidebar picks new pages up automatically, which holds for chart folders but not these.

**One claim was corrected before merge.** The ECharts page originally said the main plot supports scroll-to-zoom, which the `inside` dataZoom entry implies. Testing showed it doesn't — repeated wheel dispatches left the range unchanged. Drag-to-pan *does* work (range shifted 12–30 → 4–23 with the brush following), so the doc claims only that.

## Verification

Both pages checked in a browser against `bun run dev`. Dragging the left handle filters the main chart on both providers and shows the `formatLabel` handle labels. `bunx tsc --noEmit`, `bunx eslint`, and `bunx prettier --check` are clean.

`bun run build` was **not** run — it contends on `.next` with a running dev server. Worth a CI pass or a local build before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)