### PR TITLE
feat: landing page with camera-pan ECharts showcase

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -35,14 +35,6 @@ const nextConfig: NextConfig = {
   reactStrictMode: true,
   async redirects() {
     return [
-      // "/docs" without a trailing slash — "/docs/" would add a second hop
-      // through Next's trailing-slash normalization redirect.
-      {
-        source: "/",
-        destination: "/docs",
-        permanent: false,
-      },
-
       // Neither provider has an index page — the intro is shared at /docs — so a
       // bare provider URL lands on that engine's components overview. /docs/recharts
       // was a real page until the Recharts-only pitch folded into the shared intro,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -335,3 +335,225 @@ text,
 tspan {
   user-select: none;
 }
+@utility easing-gradient {
+  --tw-ease-gradient-stops:
+    var(--tw-gradient-position), var(--tw-gradient-from) 0%,
+    oklch(
+        from
+          color-mix(
+            in oklch,
+            var(--tw-gradient-to, oklch(from var(--tw-gradient-from) l c h / 0))
+              0.12%,
+            var(--tw-gradient-from)
+          )
+          l c h / alpha
+      )
+      5%,
+    oklch(
+        from
+          color-mix(
+            in oklch,
+            var(--tw-gradient-to, oklch(from var(--tw-gradient-from) l c h / 0))
+              0.86%,
+            var(--tw-gradient-from)
+          )
+          l c h / alpha
+      )
+      10%,
+    oklch(
+        from
+          color-mix(
+            in oklch,
+            var(--tw-gradient-to, oklch(from var(--tw-gradient-from) l c h / 0))
+              2.66%,
+            var(--tw-gradient-from)
+          )
+          l c h / alpha
+      )
+      15%,
+    oklch(
+        from
+          color-mix(
+            in oklch,
+            var(--tw-gradient-to, oklch(from var(--tw-gradient-from) l c h / 0))
+              5.79%,
+            var(--tw-gradient-from)
+          )
+          l c h / alpha
+      )
+      20%,
+    oklch(
+        from
+          color-mix(
+            in oklch,
+            var(--tw-gradient-to, oklch(from var(--tw-gradient-from) l c h / 0))
+              10.35%,
+            var(--tw-gradient-from)
+          )
+          l c h / alpha
+      )
+      25%,
+    oklch(
+        from
+          color-mix(
+            in oklch,
+            var(--tw-gradient-to, oklch(from var(--tw-gradient-from) l c h / 0))
+              16.31%,
+            var(--tw-gradient-from)
+          )
+          l c h / alpha
+      )
+      30%,
+    oklch(
+        from
+          color-mix(
+            in oklch,
+            var(--tw-gradient-to, oklch(from var(--tw-gradient-from) l c h / 0))
+              23.52%,
+            var(--tw-gradient-from)
+          )
+          l c h / alpha
+      )
+      35%,
+    oklch(
+        from
+          color-mix(
+            in oklch,
+            var(--tw-gradient-to, oklch(from var(--tw-gradient-from) l c h / 0))
+              31.74%,
+            var(--tw-gradient-from)
+          )
+          l c h / alpha
+      )
+      40%,
+    oklch(
+        from
+          color-mix(
+            in oklch,
+            var(--tw-gradient-to, oklch(from var(--tw-gradient-from) l c h / 0))
+              40.69%,
+            var(--tw-gradient-from)
+          )
+          l c h / alpha
+      )
+      45%,
+    oklch(
+        from
+          color-mix(
+            in oklch,
+            var(--tw-gradient-to, oklch(from var(--tw-gradient-from) l c h / 0))
+              50%,
+            var(--tw-gradient-from)
+          )
+          l c h / alpha
+      )
+      50%,
+    oklch(
+        from
+          color-mix(
+            in oklch,
+            var(--tw-gradient-to, oklch(from var(--tw-gradient-from) l c h / 0))
+              59.31%,
+            var(--tw-gradient-from)
+          )
+          l c h / alpha
+      )
+      55%,
+    oklch(
+        from
+          color-mix(
+            in oklch,
+            var(--tw-gradient-to, oklch(from var(--tw-gradient-from) l c h / 0))
+              68.26%,
+            var(--tw-gradient-from)
+          )
+          l c h / alpha
+      )
+      60%,
+    oklch(
+        from
+          color-mix(
+            in oklch,
+            var(--tw-gradient-to, oklch(from var(--tw-gradient-from) l c h / 0))
+              76.48%,
+            var(--tw-gradient-from)
+          )
+          l c h / alpha
+      )
+      65%,
+    oklch(
+        from
+          color-mix(
+            in oklch,
+            var(--tw-gradient-to, oklch(from var(--tw-gradient-from) l c h / 0))
+              83.69%,
+            var(--tw-gradient-from)
+          )
+          l c h / alpha
+      )
+      70%,
+    oklch(
+        from
+          color-mix(
+            in oklch,
+            var(--tw-gradient-to, oklch(from var(--tw-gradient-from) l c h / 0))
+              89.65%,
+            var(--tw-gradient-from)
+          )
+          l c h / alpha
+      )
+      75%,
+    oklch(
+        from
+          color-mix(
+            in oklch,
+            var(--tw-gradient-to, oklch(from var(--tw-gradient-from) l c h / 0))
+              96.21%,
+            var(--tw-gradient-from)
+          )
+          l c h / alpha
+      )
+      80%,
+    oklch(
+        from
+          color-mix(
+            in oklch,
+            var(--tw-gradient-to, oklch(from var(--tw-gradient-from) l c h / 0))
+              97.34%,
+            var(--tw-gradient-from)
+          )
+          l c h / alpha
+      )
+      85%,
+    oklch(
+        from
+          color-mix(
+            in oklch,
+            var(--tw-gradient-to, oklch(from var(--tw-gradient-from) l c h / 0))
+              99.14%,
+            var(--tw-gradient-from)
+          )
+          l c h / alpha
+      )
+      90%,
+    oklch(
+        from
+          color-mix(
+            in oklch,
+            var(--tw-gradient-to, oklch(from var(--tw-gradient-from) l c h / 0))
+              99.88%,
+            var(--tw-gradient-from)
+          )
+          l c h / alpha
+      )
+      95%,
+    oklch(
+        from
+          var(--tw-gradient-to, oklch(from var(--tw-gradient-from) l c h / 0)) l
+          c h / alpha
+      )
+      100%;
+  /* !important so composing with from-* / to-* works: those utilities also set
+     --tw-gradient-stops and would otherwise win the cascade over this one. */
+  --tw-gradient-stops: var(--tw-ease-gradient-stops) !important;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -86,10 +86,11 @@ export const metadata: Metadata = {
   },
 };
 
-// "/" only redirects, so entity urls point at /docs — the canonical 200 URL the
-// sitemap advertises. The #fragment @ids stay anchored to the bare origin: they
-// are opaque identifiers, and the docs pages reference them cross-page.
-const canonicalHome = absoluteUrl("/docs");
+// "/" serves the landing page, so entity urls point at the bare origin — the
+// canonical 200 URL the sitemap advertises. The #fragment @ids stay anchored to
+// the bare origin: they are opaque identifiers, and the docs pages reference
+// them cross-page.
+const canonicalHome = SITE_URL;
 
 const structuredData = {
   "@context": "https://schema.org",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,19 +1,66 @@
+import { SITE_DESCRIPTION, SITE_TITLE } from "@/globals/constants/site";
+import { ChartStage } from "@/components/landing/chart-stage";
+import { ArrowRight02Icon } from "@hugeicons/core-free-icons";
+import EvilChartWordmark from "@/assets/logos/evilchart";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Button } from "@/components/ui/button";
 import type { Metadata } from "next";
-import Image from "next/image";
+import Link from "next/link";
 
 export const metadata: Metadata = {
-  title: "Evil Charts",
-  description:
-    "A collection of beautifully designed, customizable chart components for React.",
+  title: SITE_TITLE,
+  description: SITE_DESCRIPTION,
 };
+
+const GITHUB_URL = "https://github.com/legions-developer/evilcharts";
+
+function GithubIcon() {
+  return (
+    <svg className="size-3.5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55 0-.27-.01-1.17-.02-2.12-3.2.7-3.87-1.36-3.87-1.36-.52-1.33-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.19 1.76 1.19 1.03 1.76 2.69 1.25 3.35.96.1-.75.4-1.25.72-1.54-2.55-.29-5.23-1.28-5.23-5.68 0-1.26.45-2.28 1.19-3.09-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.17 1.18a11.1 11.1 0 0 1 2.89-.39c.98 0 1.97.13 2.89.39 2.2-1.49 3.16-1.18 3.16-1.18.63 1.59.24 2.76.12 3.05.74.81 1.19 1.83 1.19 3.09 0 4.41-2.69 5.38-5.25 5.67.41.35.78 1.05.78 2.12 0 1.54-.01 2.77-.01 3.15 0 .3.2.67.8.55A11.51 11.51 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z" />
+    </svg>
+  );
+}
 
 export default function Home() {
   return (
-    <div className="flex h-screen w-full items-center justify-center">
-      <div className="flex flex-row gap-8">
-        <Image src="/web/logo.svg" alt="EvilCharts" width={50} height={50} />
-        <Image src="/web/logo-wordmark.svg" alt="EvilCharts" width={300} height={300} />
+    <main className="bg-background relative flex min-h-dvh flex-col overflow-hidden lg:h-dvh">
+      <section className="relative z-10 flex flex-col justify-center px-6 pt-20 pb-10 sm:px-12 lg:h-full lg:w-[44%] lg:min-w-105 lg:items-center lg:px-12 lg:pt-0 lg:pb-0">
+        <div className="flex w-full max-w-md flex-col gap-7">
+          <h1>
+            <EvilChartWordmark className="text-foreground h-9 w-auto" />
+            <span className="sr-only">EvilCharts</span>
+          </h1>
+          <p className="text-muted-foreground text-base text-[15px]">
+            Animated, interactive chart components for React. Built on Recharts and Apache ECharts,
+            styled for shadcn/ui — copy, paste, and ship beautiful charts.
+          </p>
+          <div className="flex flex-wrap items-center gap-3">
+            <Button nativeButton={false} render={<Link href="/docs" />}>
+              Browse Charts <HugeiconsIcon icon={ArrowRight02Icon} />
+            </Button>
+            <Button
+              variant="outline"
+              nativeButton={false}
+              render={<a href={GITHUB_URL} target="_blank" rel="noreferrer" />}
+            >
+              <GithubIcon />
+              Star on GitHub
+            </Button>
+          </div>
+        </div>
+      </section>
+      <div className="relative h-[56dvh] w-full lg:absolute lg:inset-y-0 lg:right-0 lg:h-auto lg:w-[60%]">
+        <ChartStage className="absolute inset-0" />
+        <div
+          aria-hidden
+          className="easing-gradient from-background pointer-events-none absolute inset-x-0 top-0 h-24 bg-linear-to-b lg:hidden"
+        />
+        <div
+          aria-hidden
+          className="easing-gradient from-background pointer-events-none absolute inset-y-0 left-0 hidden w-1/5 bg-linear-to-r lg:block"
+        />
       </div>
-    </div>
+    </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,28 @@ export const metadata: Metadata = {
   description: SITE_DESCRIPTION,
 };
 
+// ISR: the page is served from cache and re-rendered (with a fresh star
+// count) at most once an hour.
+export const revalidate = 3600;
+
 const GITHUB_URL = "https://github.com/legions-developer/evilcharts";
+
+async function getGithubStars(): Promise<number | null> {
+  try {
+    const res = await fetch("https://api.github.com/repos/legions-developer/evilcharts", {
+      next: { revalidate: 3600 },
+      headers: { Accept: "application/vnd.github+json" },
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { stargazers_count?: number };
+    return typeof data.stargazers_count === "number" ? data.stargazers_count : null;
+  } catch {
+    return null;
+  }
+}
+
+const formatStars = (count: number) =>
+  count >= 1000 ? `${(count / 1000).toFixed(1).replace(/\.0$/, "")}k` : String(count);
 
 function GithubIcon() {
   return (
@@ -22,7 +43,9 @@ function GithubIcon() {
   );
 }
 
-export default function Home() {
+export default async function Home() {
+  const stars = await getGithubStars();
+
   return (
     <main className="bg-background relative flex min-h-dvh flex-col overflow-hidden lg:h-dvh">
       <section className="relative z-10 flex flex-col justify-center px-6 pt-20 pb-10 sm:px-12 lg:h-full lg:w-[44%] lg:min-w-105 lg:items-center lg:px-12 lg:pt-0 lg:pb-0">
@@ -46,6 +69,11 @@ export default function Home() {
             >
               <GithubIcon />
               Star on GitHub
+              {stars !== null && (
+                <span className="text-muted-foreground border-l pl-1.5 font-mono text-xs tabular-nums">
+                  {formatStars(stars)}
+                </span>
+              )}
             </Button>
           </div>
         </div>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -8,9 +8,13 @@ export const revalidate = false;
 export default function sitemap(): MetadataRoute.Sitemap {
   const now = new Date();
 
-  // "/" is absent on purpose: it redirects to /docs, and a sitemap should only
-  // list canonical URLs that return 200.
   const staticEntries: MetadataRoute.Sitemap = [
+    {
+      url: absoluteUrl("/"),
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 1,
+    },
     {
       url: absoluteUrl("/docs"),
       lastModified: now,

--- a/src/components/landing/chart-stage.tsx
+++ b/src/components/landing/chart-stage.tsx
@@ -1,18 +1,26 @@
 "use client";
 
 import {
+  LandingBumpLineChart,
   LandingCircleRadarChart,
   LandingComposedChart,
   LandingDashedLineChart,
   LandingDonutPieChart,
   LandingDottedAreaChart,
   LandingDuotoneBarChart,
+  LandingExpandedAreaChart,
   LandingGlowingLineChart,
   LandingGradientAreaChart,
   LandingGradientBarChart,
+  LandingHatchedAreaChart,
   LandingHatchedBarChart,
+  LandingHorizontalBarChart,
+  LandingLinesAreaChart,
+  LandingLinesRadarChart,
+  LandingPaddedPieChart,
   LandingRadarChart,
   LandingSemiRadialChart,
+  LandingStackedBarChart,
   LandingStepLineChart,
   LandingStrippedBarChart,
 } from "./landing-chart-cards";
@@ -34,13 +42,13 @@ import { EChartsLatencyAreaChart } from "@/registry/blocks/echarts/b-latency-ech
 import { EChartsRideRadialChart } from "@/registry/blocks/echarts/b-ride-echarts-radial-chart";
 import { EChartsPeakBarChart } from "@/registry/blocks/echarts/b-peak-echarts-bar-chart";
 import { EChartsGridBarChart } from "@/registry/blocks/echarts/b-grid-echarts-bar-chart";
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
+import { animate, cubicBezier, motion, useReducedMotion } from "motion/react";
 import { getIconForLanguageExtension } from "@/assets/language/icons";
-import { useEffect, useRef, useState, type ReactNode } from "react";
-import { motion, useReducedMotion } from "motion/react";
 import { cn } from "@/lib/utils";
 
-const CANVAS_W = 3600;
-const CANVAS_H = 2500;
+const CANVAS_W = 3480;
+const CANVAS_H = 2520;
 
 // Every card keeps a fixed slot on the canvas — only the "camera" (the canvas
 // transform) ever moves, so focus changes read as pans, not reshuffles.
@@ -57,48 +65,81 @@ type StageCard = {
 const CARDS: StageCard[] = [
   // prettier-ignore
   ...[
-    { id: "line", title: "payouts-line-chart", x: 60, y: 80, w: 510, h: 320, node: <EChartsPayoutsLineChart /> },
-    { id: "radar", title: "radar-chart", x: 70, y: 500, w: 470, h: 290, node: <LandingRadarChart /> },
-    { id: "duotone-bar", title: "duotone-bar-chart", x: 60, y: 890, w: 470, h: 290, node: <LandingDuotoneBarChart /> },
-    { id: "gradient-bar", title: "gradient-bar-chart", x: 80, y: 1280, w: 470, h: 290, node: <LandingGradientBarChart /> },
-    { id: "market-share-pie", title: "market-share-pie-chart", x: 70, y: 1670, w: 510, h: 320, node: <EChartsMarketSharePieChart /> },
+    { id: "line", title: "payouts-line-chart", x: 60, y: -40, w: 510, h: 320, node: <EChartsPayoutsLineChart /> },
+    { id: "radar", title: "radar-chart", x: 60, y: 320, w: 470, h: 290, node: <LandingRadarChart /> },
+    { id: "duotone-bar", title: "duotone-bar-chart", x: 60, y: 650, w: 470, h: 290, node: <LandingDuotoneBarChart /> },
+    { id: "gradient-bar", title: "gradient-bar-chart", x: 60, y: 980, w: 470, h: 290, node: <LandingGradientBarChart /> },
+    { id: "market-share-pie", title: "market-share-pie-chart", x: 60, y: 1310, w: 510, h: 320, node: <EChartsMarketSharePieChart /> },
+    { id: "hatched-area", title: "hatched-area-chart", x: 60, y: 1670, w: 470, h: 290, node: <LandingHatchedAreaChart /> },
+    { id: "stacked-bar", title: "stacked-bar-chart", x: 60, y: 2000, w: 480, h: 300, node: <LandingStackedBarChart /> },
 
-    { id: "area", title: "portfolio-area-chart", x: 650, y: 40, w: 510, h: 320, node: <EChartsPortfolioAreaChart /> },
-    { id: "bar", title: "peak-bar-chart", x: 660, y: 460, w: 480, h: 300, node: <EChartsPeakBarChart /> },
-    { id: "composed", title: "composed-chart", x: 650, y: 860, w: 480, h: 300, node: <LandingComposedChart /> },
-    { id: "glowing-line", title: "glowing-line-chart", x: 660, y: 1260, w: 470, h: 290, node: <LandingGlowingLineChart /> },
-    { id: "cache-tiers-radial", title: "cache-tiers-radial-chart", x: 650, y: 1650, w: 510, h: 320, node: <EChartsCacheTiersRadialChart /> },
-    { id: "dotted-area", title: "dotted-area-chart", x: 660, y: 2070, w: 470, h: 290, node: <LandingDottedAreaChart /> },
+    { id: "area", title: "portfolio-area-chart", x: 615, y: 40, w: 510, h: 320, node: <EChartsPortfolioAreaChart /> },
+    { id: "bar", title: "peak-bar-chart", x: 615, y: 400, w: 480, h: 300, node: <EChartsPeakBarChart /> },
+    { id: "composed", title: "composed-chart", x: 615, y: 740, w: 480, h: 300, node: <LandingComposedChart /> },
+    { id: "glowing-line", title: "glowing-line-chart", x: 615, y: 1080, w: 470, h: 290, node: <LandingGlowingLineChart /> },
+    { id: "cache-tiers-radial", title: "cache-tiers-radial-chart", x: 615, y: 1410, w: 510, h: 320, node: <EChartsCacheTiersRadialChart /> },
+    { id: "dotted-area", title: "dotted-area-chart", x: 615, y: 1770, w: 470, h: 290, node: <LandingDottedAreaChart /> },
+    { id: "bump-line", title: "bump-line-chart", x: 615, y: 2100, w: 470, h: 290, node: <LandingBumpLineChart /> },
 
-    { id: "pie", title: "revenue-mix-pie-chart", x: 1250, y: 90, w: 510, h: 320, node: <EChartsRevenueMixPieChart /> },
-    { id: "radial", title: "budget-radial-chart", x: 1240, y: 510, w: 520, h: 330, node: <EChartsBudgetRadialChart /> },
-    { id: "hatched-bar", title: "hatched-bar-chart", x: 1250, y: 940, w: 480, h: 300, node: <LandingHatchedBarChart /> },
-    { id: "donut", title: "donut-pie-chart", x: 1260, y: 1340, w: 470, h: 300, node: <LandingDonutPieChart /> },
-    { id: "shipments-line", title: "shipments-line-chart", x: 1240, y: 1740, w: 510, h: 320, node: <EChartsShipmentsLineChart /> },
-    { id: "circle-radar", title: "circle-radar-chart", x: 1250, y: 2160, w: 470, h: 290, node: <LandingCircleRadarChart /> },
+    { id: "pie", title: "revenue-mix-pie-chart", x: 1170, y: 200, w: 510, h: 320, node: <EChartsRevenueMixPieChart /> },
+    { id: "radial", title: "budget-radial-chart", x: 1170, y: 560, w: 520, h: 330, node: <EChartsBudgetRadialChart /> },
+    { id: "hatched-bar", title: "hatched-bar-chart", x: 1170, y: 930, w: 480, h: 300, node: <LandingHatchedBarChart /> },
+    { id: "donut", title: "donut-pie-chart", x: 1170, y: 1270, w: 470, h: 300, node: <LandingDonutPieChart /> },
+    { id: "shipments-line", title: "shipments-line-chart", x: 1170, y: 1610, w: 510, h: 320, node: <EChartsShipmentsLineChart /> },
+    { id: "circle-radar", title: "circle-radar-chart", x: 1170, y: 1970, w: 470, h: 290, node: <LandingCircleRadarChart /> },
 
-    { id: "gradient-area", title: "gradient-area-chart", x: 1830, y: 60, w: 480, h: 300, node: <LandingGradientAreaChart /> },
-    { id: "semi-radial", title: "semi-radial-chart", x: 1840, y: 460, w: 480, h: 300, node: <LandingSemiRadialChart /> },
-    { id: "sankey", title: "pipeline-sankey-chart", x: 1830, y: 860, w: 520, h: 330, node: <EChartsPipelineSankeyChart /> },
-    { id: "dashed-line", title: "dashed-line-chart", x: 1840, y: 1290, w: 470, h: 290, node: <LandingDashedLineChart /> },
-    { id: "monospace-bar", title: "monospace-bar-chart", x: 1830, y: 1680, w: 510, h: 320, node: <EChartsMonospaceBarChart /> },
-    { id: "progress-rings-pie", title: "progress-rings-pie-chart", x: 1840, y: 2100, w: 510, h: 320, node: <EChartsProgressRingsPieChart /> },
+    { id: "gradient-area", title: "gradient-area-chart", x: 1735, y: 40, w: 480, h: 300, node: <LandingGradientAreaChart /> },
+    { id: "semi-radial", title: "semi-radial-chart", x: 1735, y: 380, w: 480, h: 300, node: <LandingSemiRadialChart /> },
+    { id: "sankey", title: "pipeline-sankey-chart", x: 1735, y: 720, w: 520, h: 330, node: <EChartsPipelineSankeyChart /> },
+    { id: "dashed-line", title: "dashed-line-chart", x: 1735, y: 1090, w: 470, h: 290, node: <LandingDashedLineChart /> },
+    { id: "monospace-bar", title: "monospace-bar-chart", x: 1735, y: 1420, w: 510, h: 320, node: <EChartsMonospaceBarChart /> },
+    { id: "progress-rings-pie", title: "progress-rings-pie-chart", x: 1735, y: 1780, w: 510, h: 320, node: <EChartsProgressRingsPieChart /> },
+    { id: "lines-area", title: "lines-area-chart", x: 1735, y: 2140, w: 470, h: 290, node: <LandingLinesAreaChart /> },
 
-    { id: "latency-area", title: "latency-area-chart", x: 2420, y: 100, w: 510, h: 320, node: <EChartsLatencyAreaChart /> },
-    { id: "allocation-sankey", title: "allocation-sankey-chart", x: 2410, y: 520, w: 520, h: 330, node: <EChartsAllocationSankeyChart /> },
-    { id: "grid-bar", title: "grid-bar-chart", x: 2420, y: 950, w: 480, h: 300, node: <EChartsGridBarChart /> },
-    { id: "reliability-pie", title: "reliability-pie-chart", x: 2430, y: 1350, w: 500, h: 320, node: <EChartsReliabilityScorePieChart /> },
-    { id: "stripped-bar", title: "stripped-bar-chart", x: 2420, y: 1770, w: 470, h: 290, node: <LandingStrippedBarChart /> },
+    { id: "latency-area", title: "latency-area-chart", x: 2300, y: 60, w: 510, h: 320, node: <EChartsLatencyAreaChart /> },
+    { id: "allocation-sankey", title: "allocation-sankey-chart", x: 2300, y: 420, w: 520, h: 330, node: <EChartsAllocationSankeyChart /> },
+    { id: "grid-bar", title: "grid-bar-chart", x: 2300, y: 790, w: 480, h: 300, node: <EChartsGridBarChart /> },
+    { id: "reliability-pie", title: "reliability-pie-chart", x: 2300, y: 1130, w: 500, h: 320, node: <EChartsReliabilityScorePieChart /> },
+    { id: "stripped-bar", title: "stripped-bar-chart", x: 2300, y: 1490, w: 470, h: 290, node: <LandingStrippedBarChart /> },
+    { id: "horizontal-bar", title: "horizontal-bar-chart", x: 2300, y: 1820, w: 480, h: 300, node: <LandingHorizontalBarChart /> },
+    { id: "lines-radar", title: "lines-radar-chart", x: 2300, y: 2160, w: 470, h: 290, node: <LandingLinesRadarChart /> },
 
-    { id: "audience-area", title: "audience-area-chart", x: 3010, y: 60, w: 510, h: 320, node: <EChartsAudienceAreaChart /> },
-    { id: "ride-radial", title: "ride-radial-chart", x: 3020, y: 480, w: 520, h: 330, node: <EChartsRideRadialChart /> },
-    { id: "benchmark-area", title: "benchmark-area-chart", x: 3010, y: 910, w: 510, h: 320, node: <EChartsBenchmarkAreaChart /> },
-    { id: "step-line", title: "step-line-chart", x: 3020, y: 1330, w: 470, h: 290, node: <LandingStepLineChart /> },
+    { id: "audience-area", title: "audience-area-chart", x: 2865, y: 40, w: 510, h: 320, node: <EChartsAudienceAreaChart /> },
+    { id: "ride-radial", title: "ride-radial-chart", x: 2865, y: 400, w: 520, h: 330, node: <EChartsRideRadialChart /> },
+    { id: "benchmark-area", title: "benchmark-area-chart", x: 2865, y: 770, w: 510, h: 320, node: <EChartsBenchmarkAreaChart /> },
+    { id: "step-line", title: "step-line-chart", x: 2865, y: 1130, w: 470, h: 290, node: <LandingStepLineChart /> },
+    { id: "expanded-area", title: "expanded-area-chart", x: 2865, y: 1460, w: 480, h: 300, node: <LandingExpandedAreaChart /> },
+    { id: "padded-pie", title: "padded-pie-chart", x: 2865, y: 1800, w: 470, h: 300, node: <LandingPaddedPieChart /> },
   ],
 ];
 
-const FOCUS_INTERVAL_MS = 3600;
+const FOCUS_INTERVAL_MS = 4600;
 const START_INDEX = CARDS.findIndex((card) => card.id === "hatched-bar");
+// Never hop to a card bordering the current one — a focus change should be a
+// real flight (roughly two column/row pitches away or more).
+const MIN_HOP_DISTANCE = 1100;
+
+const hopDistance = (a: number, b: number) => {
+  const ca = CARDS[a];
+  const cb = CARDS[b];
+  return Math.hypot(ca.x + ca.w / 2 - cb.x - cb.w / 2, ca.y + ca.h / 2 - cb.y - cb.h / 2);
+};
+
+const clamp = (min: number, value: number, max: number) => Math.min(max, Math.max(min, value));
+
+// ── Camera model ─────────────────────────────────────────────────────────────
+// The camera is (lookAt, zoom): the canvas point under the viewport center and
+// the scale it renders at. Every frame derives the css transform from those
+// two, so the look-at point travels a mathematically straight line while the
+// zoom breathes — animating translate and scale as separate channels instead
+// made the view veer sideways whenever the zoom dipped.
+//
+// GTA-character-switch profile: the look-at glides on one S-curve (slow, fast
+// middle, slow) while the zoom follows a sin² bell — zero velocity at both
+// ends, deepest exactly mid-flight.
+const flightPanEase = cubicBezier(0.65, 0, 0.35, 1);
+const flightDurationFor = (distance: number) => clamp(1.35, 0.95 + distance / 1050, 2.7);
+const flightZoomOutFor = (distance: number) => clamp(0.68, 0.86 - distance * 0.00006, 0.86);
 
 function shuffled(length: number): number[] {
   const order = Array.from({ length }, (_, i) => i);
@@ -108,8 +149,6 @@ function shuffled(length: number): number[] {
   }
   return order;
 }
-
-const clamp = (min: number, value: number, max: number) => Math.min(max, Math.max(min, value));
 
 function CardShell({ title, children }: { title: string; children: ReactNode }) {
   return (
@@ -129,8 +168,10 @@ function CardShell({ title, children }: { title: string; children: ReactNode }) 
 
 export function ChartStage({ className }: { className?: string }) {
   const viewportRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLDivElement>(null);
   const [viewport, setViewport] = useState({ w: 0, h: 0 });
   const [active, setActive] = useState(START_INDEX);
+  const [prevActive, setPrevActive] = useState(START_INDEX);
   const [hovered, setHovered] = useState<number | null>(null);
   const [paused, setPaused] = useState(false);
   // False until the first focus change: the camera must render already settled
@@ -138,6 +179,8 @@ export function ChartStage({ className }: { className?: string }) {
   const [engaged, setEngaged] = useState(false);
   const queueRef = useRef<number[]>([]);
   const lastPickRef = useRef(START_INDEX);
+  const shownRef = useRef(START_INDEX);
+  const flightRef = useRef<ReturnType<typeof animate> | null>(null);
   const reducedMotion = useReducedMotion();
 
   useEffect(() => {
@@ -155,13 +198,23 @@ export function ChartStage({ className }: { className?: string }) {
     const timer = setInterval(() => {
       if (queueRef.current.length === 0) {
         queueRef.current = shuffled(CARDS.length);
-        if (queueRef.current[0] === lastPickRef.current) {
-          queueRef.current.push(queueRef.current.shift()!);
-        }
       }
-      lastPickRef.current = queueRef.current.shift()!;
+      const current = lastPickRef.current;
+      // First queued card that is far enough away; when the cycle's tail only
+      // holds nearby cards, take the farthest of them instead of stalling.
+      let pickAt = queueRef.current.findIndex((i) => hopDistance(i, current) >= MIN_HOP_DISTANCE);
+      if (pickAt === -1) {
+        pickAt = queueRef.current.reduce(
+          (best, i, k, queue) =>
+            hopDistance(i, current) > hopDistance(queue[best], current) ? k : best,
+          0,
+        );
+      }
+      const next = queueRef.current.splice(pickAt, 1)[0];
+      setPrevActive(current);
+      lastPickRef.current = next;
       setEngaged(true);
-      setActive(lastPickRef.current);
+      setActive(next);
     }, FOCUS_INTERVAL_MS);
     return () => clearInterval(timer);
   }, [reducedMotion, paused]);
@@ -169,10 +222,58 @@ export function ChartStage({ className }: { className?: string }) {
   const measured = viewport.w > 0 && viewport.h > 0;
   const scale = measured ? clamp(0.5, Math.min(viewport.w / 1050, viewport.h / 950), 0.9) : 0.7;
   const focus = CARDS[active];
-  // The active card always lands dead-center; the dot field extends far past
-  // the canvas so corner focuses never expose a bare edge.
-  const cameraX = viewport.w / 2 - (focus.x + focus.w / 2) * scale;
-  const cameraY = viewport.h / 2 - (focus.y + focus.h / 2) * scale;
+  const prevFocus = CARDS[prevActive];
+  // Estimated flight length (used only for the highlight timing below — the
+  // flight itself measures its true start from the live transform).
+  const estimatedDistance = Math.hypot(
+    (focus.x + focus.w / 2 - prevFocus.x - prevFocus.w / 2) * scale,
+    (focus.y + focus.h / 2 - prevFocus.y - prevFocus.h / 2) * scale,
+  );
+  // The incoming card lights up only as the camera descends onto it.
+  const focusDelay = !reducedMotion && engaged ? flightDurationFor(estimatedDistance) * 0.65 : 0;
+
+  useLayoutEffect(() => {
+    const el = canvasRef.current;
+    if (!el || !measured) return;
+    const setCamera = (lookX: number, lookY: number, s: number) => {
+      el.style.transform = `translate(${viewport.w / 2 - lookX * s}px, ${viewport.h / 2 - lookY * s}px) scale(${s})`;
+    };
+    const targetX = focus.x + focus.w / 2;
+    const targetY = focus.y + focus.h / 2;
+
+    flightRef.current?.stop();
+    if (!engaged || reducedMotion || shownRef.current === active) {
+      // First paint, reduced motion, or a viewport resize: settle instantly.
+      setCamera(targetX, targetY, scale);
+    } else {
+      // Recover the current camera from the live transform (matrix is
+      // [s 0 0 s tx ty] because translate is applied before scale).
+      const computed = getComputedStyle(el).transform;
+      const matrix = computed !== "none" ? new DOMMatrix(computed) : null;
+      const fromScale = matrix ? matrix.a : scale;
+      const fromX = matrix ? (viewport.w / 2 - matrix.e) / fromScale : targetX;
+      const fromY = matrix ? (viewport.h / 2 - matrix.f) / fromScale : targetY;
+
+      const distance = Math.hypot((targetX - fromX) * scale, (targetY - fromY) * scale);
+      const duration = flightDurationFor(distance);
+      const zoomDepth = scale * (1 - flightZoomOutFor(distance));
+
+      flightRef.current = animate(0, 1, {
+        duration,
+        ease: "linear",
+        onUpdate: (t) => {
+          const pan = flightPanEase(t);
+          const dip = Math.sin(Math.PI * t) ** 2;
+          setCamera(
+            fromX + (targetX - fromX) * pan,
+            fromY + (targetY - fromY) * pan,
+            fromScale + (scale - fromScale) * pan - zoomDepth * dip,
+          );
+        },
+      });
+    }
+    shownRef.current = active;
+  }, [active, focus, measured, scale, viewport.w, viewport.h, engaged, reducedMotion]);
 
   return (
     <div
@@ -185,28 +286,14 @@ export function ChartStage({ className }: { className?: string }) {
       }}
     >
       {measured && (
-        <motion.div
+        <div
+          ref={canvasRef}
           className="absolute top-0 left-0 will-change-transform"
           style={{ width: CANVAS_W, height: CANVAS_H, transformOrigin: "0 0" }}
-          initial={false}
-          animate={{
-            x: cameraX,
-            y: cameraY,
-            scale: reducedMotion || !engaged ? scale : [null, scale * 0.94, scale],
-          }}
-          transition={
-            engaged
-              ? {
-                  x: { type: "spring", stiffness: 44, damping: 17, mass: 1.1 },
-                  y: { type: "spring", stiffness: 44, damping: 17, mass: 1.1 },
-                  scale: { duration: 1.4, times: [0, 0.45, 1], ease: "easeInOut" },
-                }
-              : { duration: 0 }
-          }
         >
           <div
             aria-hidden
-            className="absolute -inset-[1600px] bg-[radial-gradient(circle,var(--color-border)_1px,transparent_1px)] bg-[size:26px_26px] opacity-50"
+            className="absolute -inset-[1600px] bg-[radial-gradient(circle,var(--color-border)_1px,transparent_1px)] bg-[size:26px_26px] opacity-50 will-change-transform"
           />
           {CARDS.map((card, index) => {
             const isFocused = index === active;
@@ -231,8 +318,17 @@ export function ChartStage({ className }: { className?: string }) {
                   scale: !reducedMotion && isFocused ? 1.06 : 1,
                 }}
                 transition={{
-                  opacity: { duration: 0.7, ease: "easeInOut" },
-                  scale: { type: "spring", stiffness: 260, damping: 19 },
+                  opacity: {
+                    duration: 0.9,
+                    ease: "easeInOut",
+                    delay: isFocused ? focusDelay : 0,
+                  },
+                  scale: {
+                    type: "spring",
+                    stiffness: 170,
+                    damping: 26,
+                    delay: isFocused ? focusDelay : 0,
+                  },
                 }}
                 onPointerEnter={() => setHovered(index)}
                 onPointerLeave={() => setHovered((prev) => (prev === index ? null : prev))}
@@ -241,7 +337,7 @@ export function ChartStage({ className }: { className?: string }) {
               </motion.div>
             );
           })}
-        </motion.div>
+        </div>
       )}
     </div>
   );

--- a/src/components/landing/chart-stage.tsx
+++ b/src/components/landing/chart-stage.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import {
+  LandingCircleRadarChart,
+  LandingComposedChart,
+  LandingDashedLineChart,
+  LandingDonutPieChart,
+  LandingDottedAreaChart,
+  LandingDuotoneBarChart,
+  LandingGlowingLineChart,
+  LandingGradientAreaChart,
+  LandingGradientBarChart,
+  LandingHatchedBarChart,
+  LandingRadarChart,
+  LandingSemiRadialChart,
+  LandingStepLineChart,
+  LandingStrippedBarChart,
+} from "./landing-chart-cards";
+import { EChartsReliabilityScorePieChart } from "@/registry/blocks/echarts/b-reliability-score-echarts-pie-chart";
+import { EChartsProgressRingsPieChart } from "@/registry/blocks/echarts/b-progress-rings-echarts-pie-chart";
+import { EChartsCacheTiersRadialChart } from "@/registry/blocks/echarts/b-cache-tiers-echarts-radial-chart";
+import { EChartsAllocationSankeyChart } from "@/registry/blocks/echarts/b-allocation-echarts-sankey-chart";
+import { EChartsMarketSharePieChart } from "@/registry/blocks/echarts/b-market-share-echarts-pie-chart";
+import { EChartsPipelineSankeyChart } from "@/registry/blocks/echarts/b-pipeline-echarts-sankey-chart";
+import { EChartsRevenueMixPieChart } from "@/registry/blocks/echarts/b-revenue-mix-echarts-pie-chart";
+import { EChartsShipmentsLineChart } from "@/registry/blocks/echarts/b-shipments-echarts-line-chart";
+import { EChartsPortfolioAreaChart } from "@/registry/blocks/echarts/b-portfolio-echarts-area-chart";
+import { EChartsBenchmarkAreaChart } from "@/registry/blocks/echarts/b-benchmark-echarts-area-chart";
+import { EChartsMonospaceBarChart } from "@/registry/blocks/echarts/b-monospace-echarts-bar-chart";
+import { EChartsBudgetRadialChart } from "@/registry/blocks/echarts/b-budget-echarts-radial-chart";
+import { EChartsAudienceAreaChart } from "@/registry/blocks/echarts/b-audience-echarts-area-chart";
+import { EChartsPayoutsLineChart } from "@/registry/blocks/echarts/b-payouts-echarts-line-chart";
+import { EChartsLatencyAreaChart } from "@/registry/blocks/echarts/b-latency-echarts-area-chart";
+import { EChartsRideRadialChart } from "@/registry/blocks/echarts/b-ride-echarts-radial-chart";
+import { EChartsPeakBarChart } from "@/registry/blocks/echarts/b-peak-echarts-bar-chart";
+import { EChartsGridBarChart } from "@/registry/blocks/echarts/b-grid-echarts-bar-chart";
+import { getIconForLanguageExtension } from "@/assets/language/icons";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { motion, useReducedMotion } from "motion/react";
+import { cn } from "@/lib/utils";
+
+const CANVAS_W = 3600;
+const CANVAS_H = 2500;
+
+// Every card keeps a fixed slot on the canvas — only the "camera" (the canvas
+// transform) ever moves, so focus changes read as pans, not reshuffles.
+type StageCard = {
+  id: string;
+  title: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  node: ReactNode;
+};
+
+const CARDS: StageCard[] = [
+  // prettier-ignore
+  ...[
+    { id: "line", title: "payouts-line-chart", x: 60, y: 80, w: 510, h: 320, node: <EChartsPayoutsLineChart /> },
+    { id: "radar", title: "radar-chart", x: 70, y: 500, w: 470, h: 290, node: <LandingRadarChart /> },
+    { id: "duotone-bar", title: "duotone-bar-chart", x: 60, y: 890, w: 470, h: 290, node: <LandingDuotoneBarChart /> },
+    { id: "gradient-bar", title: "gradient-bar-chart", x: 80, y: 1280, w: 470, h: 290, node: <LandingGradientBarChart /> },
+    { id: "market-share-pie", title: "market-share-pie-chart", x: 70, y: 1670, w: 510, h: 320, node: <EChartsMarketSharePieChart /> },
+
+    { id: "area", title: "portfolio-area-chart", x: 650, y: 40, w: 510, h: 320, node: <EChartsPortfolioAreaChart /> },
+    { id: "bar", title: "peak-bar-chart", x: 660, y: 460, w: 480, h: 300, node: <EChartsPeakBarChart /> },
+    { id: "composed", title: "composed-chart", x: 650, y: 860, w: 480, h: 300, node: <LandingComposedChart /> },
+    { id: "glowing-line", title: "glowing-line-chart", x: 660, y: 1260, w: 470, h: 290, node: <LandingGlowingLineChart /> },
+    { id: "cache-tiers-radial", title: "cache-tiers-radial-chart", x: 650, y: 1650, w: 510, h: 320, node: <EChartsCacheTiersRadialChart /> },
+    { id: "dotted-area", title: "dotted-area-chart", x: 660, y: 2070, w: 470, h: 290, node: <LandingDottedAreaChart /> },
+
+    { id: "pie", title: "revenue-mix-pie-chart", x: 1250, y: 90, w: 510, h: 320, node: <EChartsRevenueMixPieChart /> },
+    { id: "radial", title: "budget-radial-chart", x: 1240, y: 510, w: 520, h: 330, node: <EChartsBudgetRadialChart /> },
+    { id: "hatched-bar", title: "hatched-bar-chart", x: 1250, y: 940, w: 480, h: 300, node: <LandingHatchedBarChart /> },
+    { id: "donut", title: "donut-pie-chart", x: 1260, y: 1340, w: 470, h: 300, node: <LandingDonutPieChart /> },
+    { id: "shipments-line", title: "shipments-line-chart", x: 1240, y: 1740, w: 510, h: 320, node: <EChartsShipmentsLineChart /> },
+    { id: "circle-radar", title: "circle-radar-chart", x: 1250, y: 2160, w: 470, h: 290, node: <LandingCircleRadarChart /> },
+
+    { id: "gradient-area", title: "gradient-area-chart", x: 1830, y: 60, w: 480, h: 300, node: <LandingGradientAreaChart /> },
+    { id: "semi-radial", title: "semi-radial-chart", x: 1840, y: 460, w: 480, h: 300, node: <LandingSemiRadialChart /> },
+    { id: "sankey", title: "pipeline-sankey-chart", x: 1830, y: 860, w: 520, h: 330, node: <EChartsPipelineSankeyChart /> },
+    { id: "dashed-line", title: "dashed-line-chart", x: 1840, y: 1290, w: 470, h: 290, node: <LandingDashedLineChart /> },
+    { id: "monospace-bar", title: "monospace-bar-chart", x: 1830, y: 1680, w: 510, h: 320, node: <EChartsMonospaceBarChart /> },
+    { id: "progress-rings-pie", title: "progress-rings-pie-chart", x: 1840, y: 2100, w: 510, h: 320, node: <EChartsProgressRingsPieChart /> },
+
+    { id: "latency-area", title: "latency-area-chart", x: 2420, y: 100, w: 510, h: 320, node: <EChartsLatencyAreaChart /> },
+    { id: "allocation-sankey", title: "allocation-sankey-chart", x: 2410, y: 520, w: 520, h: 330, node: <EChartsAllocationSankeyChart /> },
+    { id: "grid-bar", title: "grid-bar-chart", x: 2420, y: 950, w: 480, h: 300, node: <EChartsGridBarChart /> },
+    { id: "reliability-pie", title: "reliability-pie-chart", x: 2430, y: 1350, w: 500, h: 320, node: <EChartsReliabilityScorePieChart /> },
+    { id: "stripped-bar", title: "stripped-bar-chart", x: 2420, y: 1770, w: 470, h: 290, node: <LandingStrippedBarChart /> },
+
+    { id: "audience-area", title: "audience-area-chart", x: 3010, y: 60, w: 510, h: 320, node: <EChartsAudienceAreaChart /> },
+    { id: "ride-radial", title: "ride-radial-chart", x: 3020, y: 480, w: 520, h: 330, node: <EChartsRideRadialChart /> },
+    { id: "benchmark-area", title: "benchmark-area-chart", x: 3010, y: 910, w: 510, h: 320, node: <EChartsBenchmarkAreaChart /> },
+    { id: "step-line", title: "step-line-chart", x: 3020, y: 1330, w: 470, h: 290, node: <LandingStepLineChart /> },
+  ],
+];
+
+const FOCUS_INTERVAL_MS = 3600;
+const START_INDEX = CARDS.findIndex((card) => card.id === "hatched-bar");
+
+function shuffled(length: number): number[] {
+  const order = Array.from({ length }, (_, i) => i);
+  for (let i = order.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [order[i], order[j]] = [order[j], order[i]];
+  }
+  return order;
+}
+
+const clamp = (min: number, value: number, max: number) => Math.min(max, Math.max(min, value));
+
+function CardShell({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className="dark:bg-primary-foreground flex h-full w-full flex-col rounded-[8px] bg-[#F5F5F5] p-1">
+      <div className="flex h-7 shrink-0 items-center px-2">
+        <span className="text-muted-foreground dark:text-muted-foreground/80 flex items-center gap-1.5 font-mono text-xs [&_svg]:size-3.5">
+          {getIconForLanguageExtension("component")}
+          <span className="line-clamp-1">{title}</span>
+        </span>
+      </div>
+      <div className="bg-background min-h-0 flex-1 overflow-hidden rounded-[5px] border">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export function ChartStage({ className }: { className?: string }) {
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const [viewport, setViewport] = useState({ w: 0, h: 0 });
+  const [active, setActive] = useState(START_INDEX);
+  const [hovered, setHovered] = useState<number | null>(null);
+  const [paused, setPaused] = useState(false);
+  // False until the first focus change: the camera must render already settled
+  // on page load — any mount-time tween reads as the camera lurching into place.
+  const [engaged, setEngaged] = useState(false);
+  const queueRef = useRef<number[]>([]);
+  const lastPickRef = useRef(START_INDEX);
+  const reducedMotion = useReducedMotion();
+
+  useEffect(() => {
+    const el = viewportRef.current;
+    if (!el) return;
+    const measure = () => setViewport({ w: el.clientWidth, h: el.clientHeight });
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (reducedMotion || paused) return;
+    const timer = setInterval(() => {
+      if (queueRef.current.length === 0) {
+        queueRef.current = shuffled(CARDS.length);
+        if (queueRef.current[0] === lastPickRef.current) {
+          queueRef.current.push(queueRef.current.shift()!);
+        }
+      }
+      lastPickRef.current = queueRef.current.shift()!;
+      setEngaged(true);
+      setActive(lastPickRef.current);
+    }, FOCUS_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [reducedMotion, paused]);
+
+  const measured = viewport.w > 0 && viewport.h > 0;
+  const scale = measured ? clamp(0.5, Math.min(viewport.w / 1050, viewport.h / 950), 0.9) : 0.7;
+  const focus = CARDS[active];
+  // The active card always lands dead-center; the dot field extends far past
+  // the canvas so corner focuses never expose a bare edge.
+  const cameraX = viewport.w / 2 - (focus.x + focus.w / 2) * scale;
+  const cameraY = viewport.h / 2 - (focus.y + focus.h / 2) * scale;
+
+  return (
+    <div
+      ref={viewportRef}
+      className={cn("relative overflow-hidden", className)}
+      onPointerEnter={() => setPaused(true)}
+      onPointerLeave={() => {
+        setPaused(false);
+        setHovered(null);
+      }}
+    >
+      {measured && (
+        <motion.div
+          className="absolute top-0 left-0 will-change-transform"
+          style={{ width: CANVAS_W, height: CANVAS_H, transformOrigin: "0 0" }}
+          initial={false}
+          animate={{
+            x: cameraX,
+            y: cameraY,
+            scale: reducedMotion || !engaged ? scale : [null, scale * 0.94, scale],
+          }}
+          transition={
+            engaged
+              ? {
+                  x: { type: "spring", stiffness: 44, damping: 17, mass: 1.1 },
+                  y: { type: "spring", stiffness: 44, damping: 17, mass: 1.1 },
+                  scale: { duration: 1.4, times: [0, 0.45, 1], ease: "easeInOut" },
+                }
+              : { duration: 0 }
+          }
+        >
+          <div
+            aria-hidden
+            className="absolute -inset-[1600px] bg-[radial-gradient(circle,var(--color-border)_1px,transparent_1px)] bg-[size:26px_26px] opacity-60"
+          />
+          {CARDS.map((card, index) => {
+            const isFocused = index === active;
+            const isLifted = isFocused || (!reducedMotion && hovered === index);
+            return (
+              <motion.div
+                key={card.id}
+                className={cn(
+                  "absolute rounded-[8px] transition-shadow duration-500",
+                  isFocused ? "shadow-2xl" : "shadow-md",
+                )}
+                style={{
+                  left: card.x,
+                  top: card.y,
+                  width: card.w,
+                  height: card.h,
+                  zIndex: isFocused ? 10 : hovered === index ? 5 : 1,
+                }}
+                initial={false}
+                animate={{
+                  opacity: reducedMotion || isLifted ? 1 : 0.3,
+                  scale: !reducedMotion && isFocused ? 1.06 : 1,
+                }}
+                transition={{
+                  opacity: { duration: 0.7, ease: "easeInOut" },
+                  scale: { type: "spring", stiffness: 260, damping: 19 },
+                }}
+                onPointerEnter={() => setHovered(index)}
+                onPointerLeave={() => setHovered((prev) => (prev === index ? null : prev))}
+              >
+                <CardShell title={card.title}>{card.node}</CardShell>
+              </motion.div>
+            );
+          })}
+        </motion.div>
+      )}
+    </div>
+  );
+}

--- a/src/components/landing/chart-stage.tsx
+++ b/src/components/landing/chart-stage.tsx
@@ -206,7 +206,7 @@ export function ChartStage({ className }: { className?: string }) {
         >
           <div
             aria-hidden
-            className="absolute -inset-[1600px] bg-[radial-gradient(circle,var(--color-border)_1px,transparent_1px)] bg-[size:26px_26px] opacity-60"
+            className="absolute -inset-[1600px] bg-[radial-gradient(circle,var(--color-border)_1px,transparent_1px)] bg-[size:26px_26px] opacity-50"
           />
           {CARDS.map((card, index) => {
             const isFocused = index === active;

--- a/src/components/landing/landing-chart-cards.tsx
+++ b/src/components/landing/landing-chart-cards.tsx
@@ -1,0 +1,469 @@
+"use client";
+
+import { EChartsAreaChart, type ChartConfig } from "@/registry/charts/echarts-area-chart";
+import { EChartsComposedChart } from "@/registry/charts/echarts-composed-chart";
+import { EChartsRadialChart } from "@/registry/charts/echarts-radial-chart";
+import { EChartsRadarChart } from "@/registry/charts/echarts-radar-chart";
+import { EChartsLineChart } from "@/registry/charts/echarts-line-chart";
+import { EChartsPieChart } from "@/registry/charts/echarts-pie-chart";
+import { EChartsBarChart } from "@/registry/charts/echarts-bar-chart";
+
+const monthly = [
+  { month: "Jan", primary: 186, secondary: 80 },
+  { month: "Feb", primary: 305, secondary: 200 },
+  { month: "Mar", primary: 237, secondary: 120 },
+  { month: "Apr", primary: 173, secondary: 190 },
+  { month: "May", primary: 209, secondary: 130 },
+  { month: "Jun", primary: 264, secondary: 140 },
+  { month: "Jul", primary: 232, secondary: 178 },
+  { month: "Aug", primary: 291, secondary: 210 },
+];
+
+const radarData = [
+  { axis: "Speed", core: 92, edge: 74 },
+  { axis: "Uptime", core: 86, edge: 95 },
+  { axis: "Scale", core: 78, edge: 88 },
+  { axis: "DX", core: 95, edge: 70 },
+  { axis: "A11y", core: 82, edge: 79 },
+  { axis: "Theming", core: 90, edge: 84 },
+];
+
+const radarConfig = {
+  core: {
+    label: "Core",
+    colors: {
+      light: ["#e11d48", "#f97316", "#eab308"],
+      dark: ["#fb7185", "#fb923c", "#fde047"],
+    },
+  },
+  edge: {
+    label: "Edge",
+    colors: {
+      light: ["#0ea5e9", "#6366f1", "#a855f7"],
+      dark: ["#38bdf8", "#818cf8", "#c084fc"],
+    },
+  },
+} satisfies ChartConfig;
+
+export function LandingRadarChart() {
+  return (
+    <EChartsRadarChart data={radarData} config={radarConfig} className="h-full w-full p-3">
+      <EChartsRadarChart.PolarGrid />
+      <EChartsRadarChart.PolarAngleAxis dataKey="axis" />
+      <EChartsRadarChart.Tooltip />
+      <EChartsRadarChart.Radar dataKey="core" variant="filled">
+        <EChartsRadarChart.Dot variant="colored-border" />
+        <EChartsRadarChart.ActiveDot variant="default" />
+      </EChartsRadarChart.Radar>
+      <EChartsRadarChart.Radar dataKey="edge" variant="filled">
+        <EChartsRadarChart.Dot variant="colored-border" />
+        <EChartsRadarChart.ActiveDot variant="default" />
+      </EChartsRadarChart.Radar>
+    </EChartsRadarChart>
+  );
+}
+
+const composedData = [
+  { month: "Jan", volume: 4200, trend: 1800 },
+  { month: "Feb", volume: 5800, trend: 2400 },
+  { month: "Mar", volume: 4100, trend: 1600 },
+  { month: "Apr", volume: 6200, trend: 2800 },
+  { month: "May", volume: 5400, trend: 2200 },
+  { month: "Jun", volume: 7800, trend: 3400 },
+  { month: "Jul", volume: 6100, trend: 2600 },
+  { month: "Aug", volume: 8200, trend: 3800 },
+  { month: "Sep", volume: 5900, trend: 2500 },
+  { month: "Oct", volume: 6800, trend: 3000 },
+  { month: "Nov", volume: 7200, trend: 3200 },
+  { month: "Dec", volume: 9100, trend: 4200 },
+];
+
+const composedConfig = {
+  volume: {
+    label: "Volume",
+    colors: {
+      light: ["#0284c7", "#4f46e5"],
+      dark: ["#38bdf8", "#818cf8"],
+    },
+  },
+  trend: {
+    label: "Trend",
+    colors: {
+      light: ["#ea580c", "#db2777"],
+      dark: ["#fb923c", "#f472b6"],
+    },
+  },
+} satisfies ChartConfig;
+
+export function LandingComposedChart() {
+  return (
+    <EChartsComposedChart
+      data={composedData}
+      config={composedConfig}
+      xDataKey="month"
+      className="h-full w-full p-3"
+    >
+      <EChartsComposedChart.Grid />
+      <EChartsComposedChart.XAxis dataKey="month" />
+      <EChartsComposedChart.Tooltip />
+      <EChartsComposedChart.Bar dataKey="volume" />
+      <EChartsComposedChart.Line dataKey="trend" />
+    </EChartsComposedChart>
+  );
+}
+
+const gradientAreaConfig = {
+  primary: {
+    label: "Sessions",
+    colors: {
+      light: ["#06b6d4", "#3b82f6", "#8b5cf6"],
+      dark: ["#22d3ee", "#60a5fa", "#a78bfa"],
+    },
+  },
+  secondary: {
+    label: "Signups",
+    colors: {
+      light: ["#f59e0b", "#f97316"],
+      dark: ["#fbbf24", "#fb923c"],
+    },
+  },
+} satisfies ChartConfig;
+
+export function LandingGradientAreaChart() {
+  return (
+    <EChartsAreaChart
+      data={monthly}
+      config={gradientAreaConfig}
+      className="h-full w-full p-3"
+      stackType="stacked"
+    >
+      <EChartsAreaChart.Grid />
+      <EChartsAreaChart.XAxis dataKey="month" />
+      <EChartsAreaChart.Tooltip />
+      <EChartsAreaChart.Area dataKey="primary" variant="gradient">
+        <EChartsAreaChart.ActiveDot variant="default" />
+      </EChartsAreaChart.Area>
+      <EChartsAreaChart.Area dataKey="secondary" variant="gradient">
+        <EChartsAreaChart.ActiveDot variant="default" />
+      </EChartsAreaChart.Area>
+    </EChartsAreaChart>
+  );
+}
+
+const hatchedBarConfig = {
+  primary: {
+    label: "Deploys",
+    colors: { light: ["#0d9488"], dark: ["#2dd4bf"] },
+  },
+  secondary: {
+    label: "Rollbacks",
+    colors: { light: ["#d97706"], dark: ["#fbbf24"] },
+  },
+} satisfies ChartConfig;
+
+export function LandingHatchedBarChart() {
+  return (
+    <EChartsBarChart data={monthly} config={hatchedBarConfig} className="h-full w-full p-3">
+      <EChartsBarChart.Grid />
+      <EChartsBarChart.XAxis dataKey="month" />
+      <EChartsBarChart.Tooltip />
+      <EChartsBarChart.Bar dataKey="primary" variant="hatched" />
+      <EChartsBarChart.Bar dataKey="secondary" variant="hatched" />
+    </EChartsBarChart>
+  );
+}
+
+const duotoneBarConfig = {
+  primary: {
+    label: "Streams",
+    colors: { light: ["#c026d3"], dark: ["#e879f9"] },
+  },
+  secondary: {
+    label: "Downloads",
+    colors: { light: ["#0284c7"], dark: ["#38bdf8"] },
+  },
+} satisfies ChartConfig;
+
+export function LandingDuotoneBarChart() {
+  return (
+    <EChartsBarChart data={monthly} config={duotoneBarConfig} className="h-full w-full p-3">
+      <EChartsBarChart.Grid />
+      <EChartsBarChart.XAxis dataKey="month" />
+      <EChartsBarChart.Tooltip />
+      <EChartsBarChart.Bar dataKey="primary" variant="duotone" />
+      <EChartsBarChart.Bar dataKey="secondary" variant="duotone" />
+    </EChartsBarChart>
+  );
+}
+
+const gradientBarConfig = {
+  primary: {
+    label: "Revenue",
+    colors: {
+      light: ["#f43f5e", "#ec4899", "#a855f7", "#6366f1", "#3b82f6"],
+      dark: ["#fb7185", "#f472b6", "#c084fc", "#818cf8", "#60a5fa"],
+    },
+  },
+  secondary: {
+    label: "Profit",
+    colors: {
+      light: ["#059669", "#14b8a6", "#06b6d4"],
+      dark: ["#34d399", "#2dd4bf", "#22d3ee"],
+    },
+  },
+} satisfies ChartConfig;
+
+export function LandingGradientBarChart() {
+  return (
+    <EChartsBarChart data={monthly} config={gradientBarConfig} className="h-full w-full p-3">
+      <EChartsBarChart.Grid />
+      <EChartsBarChart.XAxis dataKey="month" />
+      <EChartsBarChart.Tooltip />
+      <EChartsBarChart.Bar dataKey="primary" />
+      <EChartsBarChart.Bar dataKey="secondary" />
+    </EChartsBarChart>
+  );
+}
+
+const glowingLineConfig = {
+  primary: {
+    label: "Requests",
+    colors: {
+      light: ["#65a30d", "#16a34a"],
+      dark: ["#a3e635", "#4ade80"],
+    },
+  },
+  secondary: {
+    label: "Cache hits",
+    colors: {
+      light: ["#c026d3", "#db2777"],
+      dark: ["#e879f9", "#f472b6"],
+    },
+  },
+} satisfies ChartConfig;
+
+export function LandingGlowingLineChart() {
+  return (
+    <EChartsLineChart data={monthly} config={glowingLineConfig} className="h-full w-full p-3">
+      <EChartsLineChart.Grid />
+      <EChartsLineChart.XAxis dataKey="month" />
+      <EChartsLineChart.Tooltip />
+      <EChartsLineChart.Line dataKey="primary" strokeVariant="solid" glowing>
+        <EChartsLineChart.ActiveDot variant="ping" />
+      </EChartsLineChart.Line>
+      <EChartsLineChart.Line dataKey="secondary" strokeVariant="solid" glowing>
+        <EChartsLineChart.ActiveDot variant="ping" />
+      </EChartsLineChart.Line>
+    </EChartsLineChart>
+  );
+}
+
+const dashedLineConfig = {
+  primary: {
+    label: "This year",
+    colors: { light: ["#0891b2"], dark: ["#22d3ee"] },
+  },
+  secondary: {
+    label: "Last year",
+    colors: { light: ["#e11d48"], dark: ["#fb7185"] },
+  },
+} satisfies ChartConfig;
+
+export function LandingDashedLineChart() {
+  return (
+    <EChartsLineChart
+      data={monthly}
+      config={dashedLineConfig}
+      className="h-full w-full p-3"
+      curveType="monotone"
+    >
+      <EChartsLineChart.Grid />
+      <EChartsLineChart.XAxis dataKey="month" />
+      <EChartsLineChart.Tooltip />
+      <EChartsLineChart.Line dataKey="primary" strokeVariant="solid" strokeWidth={2}>
+        <EChartsLineChart.Dot variant="colored-border" />
+        <EChartsLineChart.ActiveDot variant="default" />
+      </EChartsLineChart.Line>
+      <EChartsLineChart.Line dataKey="secondary" strokeVariant="dashed" strokeWidth={2}>
+        <EChartsLineChart.ActiveDot variant="default" />
+      </EChartsLineChart.Line>
+    </EChartsLineChart>
+  );
+}
+
+const donutData = [
+  { channel: "search", value: 320 },
+  { channel: "social", value: 240 },
+  { channel: "direct", value: 195 },
+  { channel: "referral", value: 140 },
+  { channel: "email", value: 110 },
+];
+
+const donutConfig = {
+  search: { label: "Search", colors: { light: ["#e11d48"], dark: ["#fb7185"] } },
+  social: { label: "Social", colors: { light: ["#f97316"], dark: ["#fb923c"] } },
+  direct: { label: "Direct", colors: { light: ["#eab308"], dark: ["#facc15"] } },
+  referral: { label: "Referral", colors: { light: ["#16a34a"], dark: ["#4ade80"] } },
+  email: { label: "Email", colors: { light: ["#0284c7"], dark: ["#38bdf8"] } },
+} satisfies ChartConfig;
+
+export function LandingDonutPieChart() {
+  return (
+    <EChartsPieChart
+      data={donutData}
+      dataKey="value"
+      nameKey="channel"
+      config={donutConfig}
+      className="h-full w-full p-3"
+    >
+      <EChartsPieChart.Legend />
+      <EChartsPieChart.Tooltip />
+      <EChartsPieChart.Pie innerRadius={60} />
+    </EChartsPieChart>
+  );
+}
+
+const semiRadialData = [
+  { tier: "starter", value: 420 },
+  { tier: "growth", value: 340 },
+  { tier: "scale", value: 260 },
+  { tier: "pro", value: 180 },
+  { tier: "max", value: 120 },
+];
+
+const semiRadialConfig = {
+  starter: { label: "Starter", colors: { light: ["#f43f5e"], dark: ["#fb7185"] } },
+  growth: { label: "Growth", colors: { light: ["#ea580c"], dark: ["#fb923c"] } },
+  scale: { label: "Scale", colors: { light: ["#ca8a04"], dark: ["#facc15"] } },
+  pro: { label: "Pro", colors: { light: ["#16a34a"], dark: ["#4ade80"] } },
+  max: { label: "Max", colors: { light: ["#0ea5e9"], dark: ["#38bdf8"] } },
+} satisfies ChartConfig;
+
+export function LandingSemiRadialChart() {
+  return (
+    <EChartsRadialChart
+      data={semiRadialData}
+      nameKey="tier"
+      config={semiRadialConfig}
+      variant="semi"
+      className="h-full w-full p-3"
+    >
+      <EChartsRadialChart.Legend />
+      <EChartsRadialChart.Tooltip />
+      <EChartsRadialChart.RadialBar dataKey="value" />
+    </EChartsRadialChart>
+  );
+}
+
+const strippedBarConfig = {
+  primary: {
+    label: "Builds",
+    colors: { light: ["#7c3aed"], dark: ["#a78bfa"] },
+  },
+  secondary: {
+    label: "Releases",
+    colors: { light: ["#65a30d"], dark: ["#a3e635"] },
+  },
+} satisfies ChartConfig;
+
+export function LandingStrippedBarChart() {
+  return (
+    <EChartsBarChart data={monthly} config={strippedBarConfig} className="h-full w-full p-3">
+      <EChartsBarChart.Grid />
+      <EChartsBarChart.XAxis dataKey="month" />
+      <EChartsBarChart.Tooltip />
+      <EChartsBarChart.Bar dataKey="primary" variant="stripped" />
+      <EChartsBarChart.Bar dataKey="secondary" variant="stripped" />
+    </EChartsBarChart>
+  );
+}
+
+const stepLineConfig = {
+  primary: {
+    label: "Active users",
+    colors: { light: ["#0284c7"], dark: ["#38bdf8"] },
+  },
+  secondary: {
+    label: "New users",
+    colors: { light: ["#ea580c"], dark: ["#fb923c"] },
+  },
+} satisfies ChartConfig;
+
+export function LandingStepLineChart() {
+  return (
+    <EChartsLineChart
+      data={monthly}
+      config={stepLineConfig}
+      className="h-full w-full p-3"
+      curveType="step"
+    >
+      <EChartsLineChart.Grid />
+      <EChartsLineChart.XAxis dataKey="month" />
+      <EChartsLineChart.Tooltip />
+      <EChartsLineChart.Line dataKey="primary" strokeVariant="solid" strokeWidth={2} />
+      <EChartsLineChart.Line dataKey="secondary" strokeVariant="solid" strokeWidth={2} />
+    </EChartsLineChart>
+  );
+}
+
+const dottedAreaConfig = {
+  primary: {
+    label: "Reads",
+    colors: { light: ["#e11d48"], dark: ["#fb7185"] },
+  },
+  secondary: {
+    label: "Writes",
+    colors: { light: ["#0891b2"], dark: ["#22d3ee"] },
+  },
+} satisfies ChartConfig;
+
+export function LandingDottedAreaChart() {
+  return (
+    <EChartsAreaChart data={monthly} config={dottedAreaConfig} className="h-full w-full p-3">
+      <EChartsAreaChart.Grid />
+      <EChartsAreaChart.XAxis dataKey="month" />
+      <EChartsAreaChart.Tooltip />
+      <EChartsAreaChart.Area dataKey="primary" variant="dotted">
+        <EChartsAreaChart.ActiveDot variant="default" />
+      </EChartsAreaChart.Area>
+      <EChartsAreaChart.Area dataKey="secondary" variant="dotted">
+        <EChartsAreaChart.ActiveDot variant="default" />
+      </EChartsAreaChart.Area>
+    </EChartsAreaChart>
+  );
+}
+
+const circleRadarConfig = {
+  core: {
+    label: "Q3",
+    colors: {
+      light: ["#d97706", "#dc2626"],
+      dark: ["#fbbf24", "#f87171"],
+    },
+  },
+  edge: {
+    label: "Q4",
+    colors: {
+      light: ["#059669", "#0891b2"],
+      dark: ["#34d399", "#22d3ee"],
+    },
+  },
+} satisfies ChartConfig;
+
+export function LandingCircleRadarChart() {
+  return (
+    <EChartsRadarChart data={radarData} config={circleRadarConfig} className="h-full w-full p-3">
+      <EChartsRadarChart.PolarGrid gridType="circle" />
+      <EChartsRadarChart.PolarAngleAxis dataKey="axis" />
+      <EChartsRadarChart.Tooltip />
+      <EChartsRadarChart.Radar dataKey="core" variant="filled">
+        <EChartsRadarChart.Dot variant="colored-border" />
+        <EChartsRadarChart.ActiveDot variant="default" />
+      </EChartsRadarChart.Radar>
+      <EChartsRadarChart.Radar dataKey="edge" variant="filled">
+        <EChartsRadarChart.Dot variant="colored-border" />
+        <EChartsRadarChart.ActiveDot variant="default" />
+      </EChartsRadarChart.Radar>
+    </EChartsRadarChart>
+  );
+}

--- a/src/components/landing/landing-chart-cards.tsx
+++ b/src/components/landing/landing-chart-cards.tsx
@@ -467,3 +467,287 @@ export function LandingCircleRadarChart() {
     </EChartsRadarChart>
   );
 }
+
+const monthly3 = [
+  { month: "Jan", primary: 186, secondary: 120, tertiary: 90 },
+  { month: "Feb", primary: 305, secondary: 180, tertiary: 130 },
+  { month: "Mar", primary: 237, secondary: 150, tertiary: 170 },
+  { month: "Apr", primary: 173, secondary: 210, tertiary: 110 },
+  { month: "May", primary: 209, secondary: 160, tertiary: 190 },
+  { month: "Jun", primary: 264, secondary: 200, tertiary: 140 },
+  { month: "Jul", primary: 232, secondary: 240, tertiary: 180 },
+  { month: "Aug", primary: 291, secondary: 190, tertiary: 220 },
+];
+
+const hatchedAreaConfig = {
+  primary: {
+    label: "Compute",
+    colors: { light: ["#4f46e5"], dark: ["#818cf8"] },
+  },
+  secondary: {
+    label: "Storage",
+    colors: { light: ["#e11d48"], dark: ["#fb7185"] },
+  },
+} satisfies ChartConfig;
+
+export function LandingHatchedAreaChart() {
+  return (
+    <EChartsAreaChart
+      data={monthly}
+      config={hatchedAreaConfig}
+      className="h-full w-full p-3"
+      stackType="stacked"
+    >
+      <EChartsAreaChart.Grid />
+      <EChartsAreaChart.XAxis dataKey="month" />
+      <EChartsAreaChart.Tooltip />
+      <EChartsAreaChart.Area dataKey="primary" variant="hatched">
+        <EChartsAreaChart.ActiveDot variant="default" />
+      </EChartsAreaChart.Area>
+      <EChartsAreaChart.Area dataKey="secondary" variant="hatched">
+        <EChartsAreaChart.ActiveDot variant="default" />
+      </EChartsAreaChart.Area>
+    </EChartsAreaChart>
+  );
+}
+
+const linesAreaConfig = {
+  primary: {
+    label: "Ingest",
+    colors: { light: ["#0d9488"], dark: ["#2dd4bf"] },
+  },
+  secondary: {
+    label: "Egress",
+    colors: { light: ["#ea580c"], dark: ["#fb923c"] },
+  },
+} satisfies ChartConfig;
+
+export function LandingLinesAreaChart() {
+  return (
+    <EChartsAreaChart
+      data={monthly}
+      config={linesAreaConfig}
+      className="h-full w-full p-3"
+      stackType="stacked"
+    >
+      <EChartsAreaChart.Grid />
+      <EChartsAreaChart.XAxis dataKey="month" />
+      <EChartsAreaChart.Tooltip />
+      <EChartsAreaChart.Area dataKey="primary" variant="lines">
+        <EChartsAreaChart.ActiveDot variant="default" />
+      </EChartsAreaChart.Area>
+      <EChartsAreaChart.Area dataKey="secondary" variant="lines">
+        <EChartsAreaChart.ActiveDot variant="default" />
+      </EChartsAreaChart.Area>
+    </EChartsAreaChart>
+  );
+}
+
+const expandedAreaConfig = {
+  primary: {
+    label: "Web",
+    colors: { light: ["#0284c7"], dark: ["#38bdf8"] },
+  },
+  secondary: {
+    label: "Mobile",
+    colors: { light: ["#7c3aed"], dark: ["#a78bfa"] },
+  },
+  tertiary: {
+    label: "API",
+    colors: { light: ["#059669"], dark: ["#34d399"] },
+  },
+} satisfies ChartConfig;
+
+export function LandingExpandedAreaChart() {
+  return (
+    <EChartsAreaChart
+      data={monthly3}
+      config={expandedAreaConfig}
+      className="h-full w-full p-3"
+      stackType="expanded"
+    >
+      <EChartsAreaChart.Grid />
+      <EChartsAreaChart.XAxis dataKey="month" />
+      <EChartsAreaChart.Tooltip />
+      <EChartsAreaChart.Area dataKey="primary" variant="gradient">
+        <EChartsAreaChart.ActiveDot variant="default" />
+      </EChartsAreaChart.Area>
+      <EChartsAreaChart.Area dataKey="secondary" variant="gradient">
+        <EChartsAreaChart.ActiveDot variant="default" />
+      </EChartsAreaChart.Area>
+      <EChartsAreaChart.Area dataKey="tertiary" variant="gradient">
+        <EChartsAreaChart.ActiveDot variant="default" />
+      </EChartsAreaChart.Area>
+    </EChartsAreaChart>
+  );
+}
+
+const stackedBarConfig = {
+  primary: {
+    label: "Seed",
+    colors: { light: ["#d97706"], dark: ["#fbbf24"] },
+  },
+  secondary: {
+    label: "Series A",
+    colors: { light: ["#e11d48"], dark: ["#fb7185"] },
+  },
+  tertiary: {
+    label: "Series B",
+    colors: { light: ["#7c3aed"], dark: ["#a78bfa"] },
+  },
+} satisfies ChartConfig;
+
+export function LandingStackedBarChart() {
+  return (
+    <EChartsBarChart
+      data={monthly3}
+      config={stackedBarConfig}
+      className="h-full w-full p-3"
+      stackType="stacked"
+    >
+      <EChartsBarChart.Grid />
+      <EChartsBarChart.XAxis dataKey="month" />
+      <EChartsBarChart.Tooltip />
+      <EChartsBarChart.Bar dataKey="primary" />
+      <EChartsBarChart.Bar dataKey="secondary" />
+      <EChartsBarChart.Bar dataKey="tertiary" />
+    </EChartsBarChart>
+  );
+}
+
+const horizontalBarConfig = {
+  primary: {
+    label: "Imports",
+    colors: { light: ["#0891b2"], dark: ["#22d3ee"] },
+  },
+  secondary: {
+    label: "Exports",
+    colors: { light: ["#db2777"], dark: ["#f472b6"] },
+  },
+} satisfies ChartConfig;
+
+export function LandingHorizontalBarChart() {
+  return (
+    <EChartsBarChart
+      data={monthly}
+      config={horizontalBarConfig}
+      className="h-full w-full p-3"
+      layout="horizontal"
+    >
+      <EChartsBarChart.Grid />
+      <EChartsBarChart.XAxis dataKey="month" />
+      <EChartsBarChart.Tooltip />
+      <EChartsBarChart.Bar dataKey="primary" />
+      <EChartsBarChart.Bar dataKey="secondary" />
+    </EChartsBarChart>
+  );
+}
+
+const bumpLineConfig = {
+  primary: {
+    label: "Alpha",
+    colors: { light: ["#059669"], dark: ["#34d399"] },
+  },
+  secondary: {
+    label: "Beta",
+    colors: { light: ["#d97706"], dark: ["#fbbf24"] },
+  },
+  tertiary: {
+    label: "Gamma",
+    colors: { light: ["#2563eb"], dark: ["#60a5fa"] },
+  },
+} satisfies ChartConfig;
+
+export function LandingBumpLineChart() {
+  return (
+    <EChartsLineChart
+      data={monthly3}
+      config={bumpLineConfig}
+      className="h-full w-full p-3"
+      curveType="bump"
+    >
+      <EChartsLineChart.Grid />
+      <EChartsLineChart.XAxis dataKey="month" />
+      <EChartsLineChart.Tooltip />
+      <EChartsLineChart.Line dataKey="primary" strokeVariant="solid" strokeWidth={2}>
+        <EChartsLineChart.Dot variant="default" />
+        <EChartsLineChart.ActiveDot variant="default" />
+      </EChartsLineChart.Line>
+      <EChartsLineChart.Line dataKey="secondary" strokeVariant="solid" strokeWidth={2}>
+        <EChartsLineChart.Dot variant="default" />
+        <EChartsLineChart.ActiveDot variant="default" />
+      </EChartsLineChart.Line>
+      <EChartsLineChart.Line dataKey="tertiary" strokeVariant="solid" strokeWidth={2}>
+        <EChartsLineChart.Dot variant="default" />
+        <EChartsLineChart.ActiveDot variant="default" />
+      </EChartsLineChart.Line>
+    </EChartsLineChart>
+  );
+}
+
+const linesRadarConfig = {
+  core: {
+    label: "Current",
+    colors: {
+      light: ["#7c3aed", "#c026d3"],
+      dark: ["#a78bfa", "#e879f9"],
+    },
+  },
+  edge: {
+    label: "Target",
+    colors: {
+      light: ["#4d7c0f", "#059669"],
+      dark: ["#a3e635", "#34d399"],
+    },
+  },
+} satisfies ChartConfig;
+
+export function LandingLinesRadarChart() {
+  return (
+    <EChartsRadarChart data={radarData} config={linesRadarConfig} className="h-full w-full p-3">
+      <EChartsRadarChart.PolarGrid />
+      <EChartsRadarChart.PolarAngleAxis dataKey="axis" />
+      <EChartsRadarChart.Tooltip />
+      <EChartsRadarChart.Radar dataKey="core" variant="lines">
+        <EChartsRadarChart.Dot variant="colored-border" />
+        <EChartsRadarChart.ActiveDot variant="default" />
+      </EChartsRadarChart.Radar>
+      <EChartsRadarChart.Radar dataKey="edge" variant="lines">
+        <EChartsRadarChart.Dot variant="colored-border" />
+        <EChartsRadarChart.ActiveDot variant="default" />
+      </EChartsRadarChart.Radar>
+    </EChartsRadarChart>
+  );
+}
+
+const paddedPieData = [
+  { stack: "render", value: 340 },
+  { stack: "compute", value: 260 },
+  { stack: "storage", value: 210 },
+  { stack: "network", value: 150 },
+  { stack: "other", value: 90 },
+];
+
+const paddedPieConfig = {
+  render: { label: "Render", colors: { light: ["#c026d3"], dark: ["#e879f9"] } },
+  compute: { label: "Compute", colors: { light: ["#0891b2"], dark: ["#22d3ee"] } },
+  storage: { label: "Storage", colors: { light: ["#65a30d"], dark: ["#a3e635"] } },
+  network: { label: "Network", colors: { light: ["#ea580c"], dark: ["#fb923c"] } },
+  other: { label: "Other", colors: { light: ["#4f46e5"], dark: ["#818cf8"] } },
+} satisfies ChartConfig;
+
+export function LandingPaddedPieChart() {
+  return (
+    <EChartsPieChart
+      data={paddedPieData}
+      dataKey="value"
+      nameKey="stack"
+      config={paddedPieConfig}
+      className="h-full w-full p-3"
+    >
+      <EChartsPieChart.Legend />
+      <EChartsPieChart.Tooltip />
+      <EChartsPieChart.Pie innerRadius={30} paddingAngle={4} />
+    </EChartsPieChart>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { Button as ButtonPrimitive } from "@base-ui/react/button";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center cursor-pointer justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center cursor-pointer justify-center gap-1.5 whitespace-nowrap rounded-md text-[13px] font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary

`/` now serves a real landing page instead of redirecting to `/docs`.

- **Hero (left)** — EvilCharts wordmark, description, and two Base UI buttons: Browse Charts → `/docs`, and Star on GitHub showing the **live star count** (fetched server-side; the page is ISR-cached with `revalidate = 3600`, so it loads instantly and refreshes the count at most hourly).
- **Chart stage (right)** — **40 ECharts cards** (18 reused registry blocks + 22 landing-specific variant cards with distinct color palettes) at fixed slots on a 3480×2520 canvas with staggered columns and tight ~40px gaps. Cards use the docs `ComponentPreview` chrome (component icon + mono title, inset frame) minus the Code/Preview tabs, in ~16:9 aspect.
- **Cinematic camera** — a GTA-character-switch-style flight on every focus change: the camera is modeled as (look-at point, zoom), with the look-at gliding on a single S-curve along a mathematically straight line while the zoom follows a sin² bell (zero velocity at both ends, deepest exactly mid-flight); the CSS transform derives from both every frame. Flight duration and zoom depth scale with travel distance; the incoming card lights up only as the camera descends onto it. The random picker cycles all cards fairly but never hops to a bordering card (min ~2 pitches, farthest-available fallback). Hover pauses autoplay and chart tooltips stay interactive; `useReducedMotion` renders a static collage; first load renders settled with no camera motion.
- **Eased fades** — ported the `easing-gradient` utility (21 ease-in-out gradient stops) into `globals.css` for the hero-side/mobile fades; its stops line is `!important` so it composes with plain `from-*`/`to-*` utilities.
- **SEO plumbing** — removed the `/` → `/docs` redirect, pointed the structured-data canonical home at the bare origin, added `/` to the sitemap.
- **Button base style** — tighter icon gap and 13px label.

## Test plan

- `bun run build` passes; `tsc --noEmit` and ESLint clean
- Verified live in Chrome: dark + light themes, zero console errors with all 40 charts mounted
- Camera verified with transform telemetry: look-at path deviates ≤0.03px from a straight chord across flights, zoom spans the full flight with no discontinuities, and consecutive hops measured ≥1100 canvas px

🤖 Generated with [Claude Code](https://claude.com/claude-code)