### PR TITLE
feat: support SVG renderer in ECharts charts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ The installable registry source is the product. Site code demonstrates and deliv
 - Base UI (`@base-ui/react`) for site primitives; this codebase is not using Radix
 - Fumadocs MDX for documentation
 - Recharts 3 for SVG charts
-- ECharts 6 with modular imports and the canvas renderer
+- ECharts 6 with modular imports; Canvas is the default renderer and SVG is optional
 - Motion (`motion/react`) for animation
 - shadcn CLI registry schema/build tooling
 - ESLint 9 and Prettier with import and Tailwind class sorting plugins
@@ -79,8 +79,8 @@ An MDX `<ComponentPreview name="..." />` resolves through the generated `Index`.
 The two providers intentionally share concepts and `ChartConfig`, not rendering internals.
 
 - Recharts modules export compound components such as `EvilAreaChart`. The root owns shared state in React context and visual children such as `Area`, `XAxis`, `Grid`, `Tooltip`, and `Legend` consume it. Recharts renders SVG.
-- ECharts modules export roots such as `EChartsAreaChart`. Their child components are declarative configuration slots that return `null`; the root inspects its children and builds a typed ECharts option. ECharts is registered modularly and renders to canvas.
-- `ChartConfig` colors are exposed as `--color-<key>-<slot>` CSS variables. Recharts consumes them directly; ECharts resolves browser CSS colors before painting to canvas.
+- ECharts modules export roots such as `EChartsAreaChart`. Their child components are declarative configuration slots that return `null`; the root inspects its children and builds a typed ECharts option. ECharts is registered modularly, uses Canvas by default, and supports SVG through the root's `renderer="svg"` prop.
+- `ChartConfig` colors are exposed as `--color-<key>-<slot>` CSS variables. Recharts consumes them directly; ECharts resolves browser CSS colors before painting with the selected renderer.
 - Cartesian charts support selection, loading states, animation, tooltips/legends, and optional brush behavior. Preserve parity between provider twins where their APIs overlap, while respecting renderer-specific implementations.
 - Motion-heavy work must honor `prefers-reduced-motion`/`useReducedMotion`. Avoid option pushes or React state churn inside continuous ECharts pointer, zoom, or animation loops unless there is no imperative alternative.
 

--- a/registry.json
+++ b/registry.json
@@ -551,6 +551,19 @@
       ]
     },
     {
+      "name": "ex-svg-renderer-echarts-area-chart",
+      "registryDependencies": [
+        "@evilcharts/echarts-area-chart"
+      ],
+      "type": "registry:block",
+      "files": [
+        {
+          "path": "src/registry/examples/echarts/ex-svg-renderer-echarts-area-chart.tsx",
+          "type": "registry:block"
+        }
+      ]
+    },
+    {
       "name": "ex-brush-echarts-area-chart",
       "registryDependencies": [
         "@evilcharts/echarts-area-chart"
@@ -832,6 +845,19 @@
       "files": [
         {
           "path": "src/registry/examples/echarts/ex-echarts-line-chart.tsx",
+          "type": "registry:block"
+        }
+      ]
+    },
+    {
+      "name": "ex-svg-renderer-echarts-line-chart",
+      "registryDependencies": [
+        "@evilcharts/echarts-line-chart"
+      ],
+      "type": "registry:block",
+      "files": [
+        {
+          "path": "src/registry/examples/echarts/ex-svg-renderer-echarts-line-chart.tsx",
           "type": "registry:block"
         }
       ]
@@ -1162,6 +1188,19 @@
       ]
     },
     {
+      "name": "ex-svg-renderer-echarts-bar-chart",
+      "registryDependencies": [
+        "@evilcharts/echarts-bar-chart"
+      ],
+      "type": "registry:block",
+      "files": [
+        {
+          "path": "src/registry/examples/echarts/ex-svg-renderer-echarts-bar-chart.tsx",
+          "type": "registry:block"
+        }
+      ]
+    },
+    {
       "name": "ex-buffer-echarts-bar-chart",
       "registryDependencies": [
         "@evilcharts/echarts-bar-chart"
@@ -1461,6 +1500,19 @@
       ]
     },
     {
+      "name": "ex-svg-renderer-echarts-composed-chart",
+      "registryDependencies": [
+        "@evilcharts/echarts-composed-chart"
+      ],
+      "type": "registry:block",
+      "files": [
+        {
+          "path": "src/registry/examples/echarts/ex-svg-renderer-echarts-composed-chart.tsx",
+          "type": "registry:block"
+        }
+      ]
+    },
+    {
       "name": "ex-gradient-colors-echarts-composed-chart",
       "registryDependencies": [
         "@evilcharts/echarts-composed-chart"
@@ -1630,6 +1682,19 @@
       ]
     },
     {
+      "name": "ex-svg-renderer-echarts-radar-chart",
+      "registryDependencies": [
+        "@evilcharts/echarts-radar-chart"
+      ],
+      "type": "registry:block",
+      "files": [
+        {
+          "path": "src/registry/examples/echarts/ex-svg-renderer-echarts-radar-chart.tsx",
+          "type": "registry:block"
+        }
+      ]
+    },
+    {
       "name": "ex-lines-variant-echarts-radar-chart",
       "registryDependencies": [
         "@evilcharts/echarts-radar-chart"
@@ -1690,6 +1755,19 @@
       "files": [
         {
           "path": "src/registry/examples/echarts/ex-echarts-pie-chart.tsx",
+          "type": "registry:block"
+        }
+      ]
+    },
+    {
+      "name": "ex-svg-renderer-echarts-pie-chart",
+      "registryDependencies": [
+        "@evilcharts/echarts-pie-chart"
+      ],
+      "type": "registry:block",
+      "files": [
+        {
+          "path": "src/registry/examples/echarts/ex-svg-renderer-echarts-pie-chart.tsx",
           "type": "registry:block"
         }
       ]
@@ -1799,6 +1877,19 @@
       ]
     },
     {
+      "name": "ex-svg-renderer-echarts-radial-chart",
+      "registryDependencies": [
+        "@evilcharts/echarts-radial-chart"
+      ],
+      "type": "registry:block",
+      "files": [
+        {
+          "path": "src/registry/examples/echarts/ex-svg-renderer-echarts-radial-chart.tsx",
+          "type": "registry:block"
+        }
+      ]
+    },
+    {
       "name": "ex-semi-variant-echarts-radial-chart",
       "registryDependencies": [
         "@evilcharts/echarts-radial-chart"
@@ -1846,6 +1937,19 @@
       "files": [
         {
           "path": "src/registry/examples/echarts/ex-echarts-sankey-chart.tsx",
+          "type": "registry:block"
+        }
+      ]
+    },
+    {
+      "name": "ex-svg-renderer-echarts-sankey-chart",
+      "registryDependencies": [
+        "@evilcharts/echarts-sankey-chart"
+      ],
+      "type": "registry:block",
+      "files": [
+        {
+          "path": "src/registry/examples/echarts/ex-svg-renderer-echarts-sankey-chart.tsx",
           "type": "registry:block"
         }
       ]

--- a/src/content/docs/echarts/area-chart/static.mdx
+++ b/src/content/docs/echarts/area-chart/static.mdx
@@ -115,13 +115,13 @@ import { EChartsAreaChart, type ChartConfig } from "@/components/evilcharts/char
 </EChartsAreaChart>
 ```
 
-The one real difference is under the hood: ECharts renders to a `<canvas>`, so these children never mount as DOM. The root reads their props and compiles them into the ECharts option — same JSX, same presence semantics (omit a part and it won't render), same behavior, just declarative config instead of live DOM nodes.
+The difference is under the hood: these compound children are declarative configuration slots rather than visual React DOM nodes. The root reads their props and compiles an ECharts option, which ECharts paints with Canvas by default or SVG when `renderer="svg"`.
 
 The `config` is the same contract as every EvilCharts chart — each key maps a data key to a `label` and a per-theme `colors` array. See <Link href="/docs/chart-config">Chart Config</Link> for the full shape. Colors resolve from CSS variables at runtime, so dark mode just works.
 
 <Alert>
   <AlertContent>
-    Canvas rendering brings two small departures from the Recharts twin: multi-color gradients bake into a texture at render size (visually equivalent, rebuilt on resize), and the zoom brush is a themed mini chart driven by ECharts' native `dataZoom` instead of the custom `EvilBrush`.
+    The ECharts implementation brings two small departures from the Recharts twin: multi-color gradient areas and the `dotted`, `lines`, and `hatched` fills use offscreen canvas textures sized to the plot. With `renderer="svg"`, ECharts may embed those texture tiles as raster images inside the SVG. The zoom brush is a themed mini chart driven by ECharts' native `dataZoom` instead of the custom `EvilBrush`.
   </AlertContent>
 </Alert>
 
@@ -137,6 +137,12 @@ The `config` is the same contract as every EvilCharts chart — each key maps a 
 ## Examples
 
 Change `variant` and `strokeVariant` on an `<Area>`, or `curveType` and `stackType` on the chart, to restyle it.
+
+### SVG Renderer
+
+Pass `renderer="svg"` to the chart root to opt into ECharts' SVG renderer. Omit it to use the default Canvas renderer.
+
+<ComponentPreview title='renderer="svg"' name="ex-svg-renderer-echarts-area-chart" />
 
 ### Hover Highlight
 
@@ -194,7 +200,7 @@ Change `variant` and `strokeVariant` on an `<Area>`, or `curveType` and `stackTy
 
 ## API Reference
 
-Props are grouped by the part they belong to. On canvas each part is declarative config the root compiles, but the API mirrors the Recharts twin one-to-one.
+Props are grouped by the part they belong to. Regardless of renderer, each part is declarative config the root compiles, but the API mirrors the Recharts twin one-to-one.
 
 <ApiHeading>EChartsAreaChart</ApiHeading>
 
@@ -212,6 +218,9 @@ The root container. It owns the data, shared selection state, loading skeleton, 
   </ApiRow>
   <ApiRow name="className" type="string">
     Additional CSS classes for the chart container.
+  </ApiRow>
+  <ApiRow name="renderer" type='"canvas" | "svg"' default='"canvas"'>
+    Rendering engine used by ECharts. Use `"svg"` for an SVG-backed chart surface; omit the prop to keep the Canvas default.
   </ApiRow>
   <ApiRow name="xDataKey" type="keyof TData & string">
     Data key for the x-axis categories.
@@ -336,7 +345,7 @@ The hover tooltip. Include it to enable the tooltip; omit it and none shows. It 
 
 <ApiHeading>Legend</ApiHeading>
 
-The series legend, rendered as HTML above the canvas. Include it to show the legend; omit it and none shows. When `isClickable` is set, each entry toggles selection of its series.
+The series legend, rendered as HTML above the chart surface. Include it to show the legend; omit it and none shows. When `isClickable` is set, each entry toggles selection of its series.
 
 <ApiTable>
   <ApiRow name="variant" type='"square" | "circle" | "circle-outline" | "rounded-square" | "rounded-square-outline" | "vertical-bar" | "horizontal-bar"'>

--- a/src/content/docs/echarts/bar-chart/static.mdx
+++ b/src/content/docs/echarts/bar-chart/static.mdx
@@ -114,15 +114,21 @@ import { EChartsBarChart, type ChartConfig } from "@/components/evilcharts/chart
 </EChartsBarChart>
 ```
 
-The one real difference is under the hood: ECharts renders to a `<canvas>`, so these children never mount as DOM. The root reads their props and compiles them into the ECharts option object — same JSX, same presence semantics (omit a part and it doesn't render), but the children are declarative config, not live DOM nodes.
+The difference is under the hood: these compound children are declarative configuration slots rather than visual React DOM nodes. The root reads their props and compiles an ECharts option, which ECharts paints with Canvas by default or SVG when `renderer="svg"`.
 
 The `config` is the same contract as every EvilCharts chart — each key maps a data key to a `label` and a per-theme `colors` array. See <Link href="/docs/chart-config">Chart Config</Link> for the full shape. Colors resolve from CSS variables at runtime, so dark mode just works.
 
 <Alert>
   <AlertContent>
-    Canvas rendering brings a few small departures from the Recharts twin: the `duotone` split is baked as a single ECharts gradient (visually equivalent for single-color series), the `stripped` cap is a fixed-height band derived from the measured axis scale, the `hatched` fill is a tiling canvas texture, and the zoom brush is a themed mini chart driven by ECharts' native `dataZoom` rather than the custom `EvilBrush`.
+    The ECharts implementation brings a few small departures from the Recharts twin: the `duotone` split is a single ECharts gradient, the `stripped` cap is a fixed-height band derived from the measured axis scale, and the zoom brush is a themed mini chart driven by ECharts' native `dataZoom`. The `hatched`, `blocks`, and buffer fills use offscreen canvas tiles; with `renderer="svg"`, ECharts may embed those tiles as raster images inside the SVG.
   </AlertContent>
 </Alert>
+
+### SVG Renderer
+
+Pass `renderer="svg"` to the chart root to opt into ECharts' SVG renderer. Omit it to use the default Canvas renderer.
+
+<ComponentPreview title='renderer="svg"' name="ex-svg-renderer-echarts-bar-chart" />
 
 ### Interactive Selection
 
@@ -229,7 +235,7 @@ Examples of the bar chart with different `variants`. Each `<Bar>` sets its own `
 
 ## API Reference
 
-The props below are grouped by the part they belong to. On canvas each part is declarative config the root compiles, but the API mirrors the Recharts twin one-to-one.
+The props below are grouped by the part they belong to. Regardless of renderer, each part is declarative config the root compiles, but the API mirrors the Recharts twin one-to-one.
 
 <ApiHeading>EChartsBarChart</ApiHeading>
 
@@ -247,6 +253,9 @@ The root container. It owns the data, shared selection state, loading skeleton, 
   </ApiRow>
   <ApiRow name="className" type="string">
     Additional CSS classes for the chart container.
+  </ApiRow>
+  <ApiRow name="renderer" type='"canvas" | "svg"' default='"canvas"'>
+    Rendering engine used by ECharts. Use `"svg"` for an SVG-backed chart surface; omit the prop to keep the Canvas default.
   </ApiRow>
   <ApiRow name="stackType" type='"default" | "stacked" | "percent"' default='"default"'>
     How multiple bars combine. `"default"` renders them side by side, `"stacked"` stacks them, and `"percent"` normalizes them to a percentage distribution.
@@ -367,7 +376,7 @@ The hover tooltip. Include it to enable the tooltip; omit it and none shows. It 
 
 <ApiHeading>Legend</ApiHeading>
 
-The series legend, rendered as HTML above the canvas. Include it to show the legend; omit it and none shows. With `isClickable`, each entry toggles selection of its series.
+The series legend, rendered as HTML above the chart surface. Include it to show the legend; omit it and none shows. With `isClickable`, each entry toggles selection of its series.
 
 <ApiTable>
   <ApiRow name="variant" type='"square" | "circle" | "circle-outline" | "rounded-square" | "rounded-square-outline" | "vertical-bar" | "horizontal-bar"'>

--- a/src/content/docs/echarts/composed-chart/static.mdx
+++ b/src/content/docs/echarts/composed-chart/static.mdx
@@ -129,15 +129,21 @@ const chartConfig = {
 </EChartsComposedChart>
 ```
 
-The only real difference from the Recharts twin is under the hood. ECharts renders to a `<canvas>`, so these children never mount as DOM — the root reads their props and compiles them into the ECharts option object. Same JSX, same presence semantics (omit a part and it doesn't render), same behavior; the children are just config, not live DOM nodes.
+The difference from the Recharts twin is under the hood: these compound children are declarative configuration slots rather than visual React DOM nodes. The root reads their props and compiles an ECharts option, which ECharts paints with Canvas by default or SVG when `renderer="svg"`.
 
 The `config` is the same contract as every EvilCharts chart — each key maps a data key to a `label` and a per-theme `colors` array. See <Link href="/docs/chart-config">Chart Config</Link> for the full shape. Colors resolve from your CSS variables at runtime, so dark mode just works.
 
 <Alert>
   <AlertContent>
-    Canvas rendering brings a few small departures from the Recharts twin: multi-color bars run a vertical gradient through their color slots (horizontal-split and textured variants are single-color); the glow becomes a soft colored blur that follows each series' own color rather than an SVG filter; and the zoom brush is a themed mini chart driven by ECharts' native `dataZoom` rather than the custom `EvilBrush`.
+    The ECharts implementation brings a few small departures from the Recharts twin: multi-color bars run a vertical gradient through their color slots, the glow becomes a soft colored blur rather than the Recharts SVG filter, and the zoom brush is a themed mini chart driven by native `dataZoom`. The textured `hatched` bar fill uses an offscreen canvas tile; with `renderer="svg"`, ECharts may embed that tile as a raster image inside the SVG.
   </AlertContent>
 </Alert>
+
+### SVG Renderer
+
+Pass `renderer="svg"` to the chart root to opt into ECharts' SVG renderer. Omit it to use the default Canvas renderer.
+
+<ComponentPreview title='renderer="svg"' name="ex-svg-renderer-echarts-composed-chart" />
 
 ### Interactive Selection
 
@@ -210,7 +216,7 @@ Examples of the composed chart with different `variants`. Customize each `<Bar>`
 <ComponentPreview className="mb-0" title="<Bar enableHoverHighlight />" name="ex-hover-highlight-echarts-composed-chart"  />
 <Alert>
   <AlertContent>
-    Set `enableHoverHighlight` on a `<Bar>` to dim its other columns when you hover one, making a single data point easier to focus on. On canvas it uses ECharts' native emphasis, so nothing re-renders mid-hover.
+    Set `enableHoverHighlight` on a `<Bar>` to dim its other columns when you hover one, making a single data point easier to focus on. It uses ECharts' native emphasis, so nothing re-renders mid-hover.
   </AlertContent>
 </Alert>
 
@@ -219,13 +225,13 @@ Examples of the composed chart with different `variants`. Customize each `<Bar>`
 <ComponentPreview className="mb-0" title="<Bar glow /> and <Line glow />" name="ex-glowing-echarts-composed-chart"  />
 <Alert>
   <AlertContent>
-    Add the `glow` prop to a `<Bar>` or `<Line>` for a subtle glow. On canvas it's a soft colored blur that follows the series' own color along its length, staying faithful even on multi-stop gradients.
+    Add the `glow` prop to a `<Bar>` or `<Line>` for a subtle glow. ECharts renders it as a soft colored blur that follows the series' own color along its length, staying faithful even on multi-stop gradients.
   </AlertContent>
 </Alert>
 
 ## API Reference
 
-The chart is composed of several parts; the props below are grouped by part. On canvas each part is config the root compiles, but the API mirrors the Recharts twin one-to-one.
+The chart is composed of several parts; the props below are grouped by part. Regardless of renderer, each part is config the root compiles, but the API mirrors the Recharts twin one-to-one.
 
 <ApiHeading>EChartsComposedChart</ApiHeading>
 
@@ -243,6 +249,9 @@ The root container. It owns the data, shared selection state, loading skeleton, 
   </ApiRow>
   <ApiRow name="className" type="string">
     Additional CSS classes for the chart container.
+  </ApiRow>
+  <ApiRow name="renderer" type='"canvas" | "svg"' default='"canvas"'>
+    Rendering engine used by ECharts. Use `"svg"` for an SVG-backed chart surface; omit the prop to keep the Canvas default.
   </ApiRow>
   <ApiRow name="xDataKey" type="keyof TData & string">
     The data key for the x-axis categories. Falls back to the `<XAxis dataKey="…" />` value, then to the first data column no series claims.
@@ -297,7 +306,7 @@ A single bar series. Each `<Bar />` carries its own fill variant, radius, glow, 
     The grow-in order for this bar (the first declared series' value drives the chart). Falls back to the chart's `animationType` when omitted.
   </ApiRow>
   <ApiRow name="glow" type="boolean" default="false">
-    Applies a soft neon glow (a colored canvas shadow) to this bar.
+    Applies a soft neon glow to this bar.
   </ApiRow>
   <ApiRow name="isClickable" type="boolean" default="false">
     Lets this bar be selected by clicking it. When any series is selected, unselected series become semi-transparent.
@@ -401,7 +410,7 @@ The hover tooltip. Include it to enable the tooltip; omit it and none shows. It 
 
 <ApiHeading>Legend</ApiHeading>
 
-The series legend, rendered as HTML above the canvas. Include it to show the legend; omit it and none shows. With `isClickable`, each entry toggles selection of its series.
+The series legend, rendered as HTML above the chart surface. Include it to show the legend; omit it and none shows. With `isClickable`, each entry toggles selection of its series.
 
 <ApiTable>
   <ApiRow name="variant" type='"square" | "circle" | "circle-outline" | "rounded-square" | "rounded-square-outline" | "vertical-bar" | "horizontal-bar"'>

--- a/src/content/docs/echarts/installation.mdx
+++ b/src/content/docs/echarts/installation.mdx
@@ -4,7 +4,19 @@ description: install the evilcharts echarts components in your project
 image: /og/og-image.png
 ---
 
-The ECharts provider renders to canvas through Apache ECharts — same config contract, same install flow, built for scale.
+The ECharts provider uses Apache ECharts with Canvas by default and optional SVG rendering — same config contract, same install flow, and a renderer choice on every chart root.
+
+Omit `renderer` to keep the Canvas default, or pass `renderer="svg"` to select ECharts' SVG renderer:
+
+```tsx
+<EChartsAreaChart data={data} config={chartConfig}>
+  {/* Canvas */}
+</EChartsAreaChart>
+
+<EChartsAreaChart renderer="svg" data={data} config={chartConfig}>
+  {/* SVG renderer */}
+</EChartsAreaChart>
+```
 
 ## Steps
 <Steps>

--- a/src/content/docs/echarts/line-chart/static.mdx
+++ b/src/content/docs/echarts/line-chart/static.mdx
@@ -120,15 +120,21 @@ import { EChartsLineChart, type ChartConfig } from "@/components/evilcharts/char
 </EChartsLineChart>
 ```
 
-The one real difference from the Recharts twin is under the hood: ECharts renders to a `<canvas>`, so these children never mount as DOM. The root reads their props and compiles them into the ECharts option object. Same JSX, same presence semantics (omit a part and it doesn't render), same behavior — the children are declarative config, not live DOM nodes.
+The difference from the Recharts twin is under the hood: these compound children are declarative configuration slots rather than visual React DOM nodes. The root reads their props and compiles an ECharts option, which ECharts paints with Canvas by default or SVG when `renderer="svg"`.
 
 The `config` is the same contract as every EvilCharts chart — each key maps a data key to a `label` and a per-theme `colors` array. See <Link href="/docs/chart-config">Chart Config</Link> for the full shape. Colors resolve from your CSS variables at runtime, so dark mode just works.
 
 <Alert>
   <AlertContent>
-    Canvas rendering brings a few small departures from the Recharts twin: multi-color gradients tint each dot with the color at its x-position; the glow is layered gradient strokes stacked under the line, following the series' color in place of an SVG blur filter; and the zoom brush is a themed mini chart driven by ECharts' native `dataZoom` rather than the custom `EvilBrush`.
+    The ECharts implementation brings a few small departures from the Recharts twin: multi-color gradients tint each dot with the color at its x-position; the glow is layered gradient strokes stacked under the line, following the series' color in place of the Recharts SVG blur filter; and the zoom brush is a themed mini chart driven by ECharts' native `dataZoom` rather than the custom `EvilBrush`.
   </AlertContent>
 </Alert>
+
+### SVG Renderer
+
+Pass `renderer="svg"` to the chart root to opt into ECharts' SVG renderer. Omit it to use the default Canvas renderer.
+
+<ComponentPreview title='renderer="svg"' name="ex-svg-renderer-echarts-line-chart" />
 
 ### Interactive Selection
 
@@ -209,7 +215,7 @@ Examples with different settings. Change `strokeVariant` on a `<Line>` or `curve
 
 ## API Reference
 
-The chart is composed of several parts; the props below are grouped by part. On canvas each part is declarative config the root compiles, but the API mirrors the Recharts twin one-to-one.
+The chart is composed of several parts; the props below are grouped by part. Regardless of renderer, each part is declarative config the root compiles, but the API mirrors the Recharts twin one-to-one.
 
 <ApiHeading>EChartsLineChart</ApiHeading>
 
@@ -227,6 +233,9 @@ The root container. It owns the data, shared selection state, loading skeleton, 
   </ApiRow>
   <ApiRow name="className" type="string">
     Additional CSS classes for the chart container.
+  </ApiRow>
+  <ApiRow name="renderer" type='"canvas" | "svg"' default='"canvas"'>
+    Rendering engine used by ECharts. Use `"svg"` for an SVG-backed chart surface; omit the prop to keep the Canvas default.
   </ApiRow>
   <ApiRow name="xDataKey" type="keyof TData & string">
     The data key for the x-axis categories. Falls back to the `<XAxis dataKey="…" />` value, then to the first data column no `<Line />` claims.
@@ -354,7 +363,7 @@ The hover tooltip. Include it to enable the tooltip; omit it and none shows. It 
 
 <ApiHeading>Legend</ApiHeading>
 
-The series legend, rendered as HTML above the canvas. Include it to show the legend; omit it and none shows. With `isClickable`, each entry toggles selection of its series.
+The series legend, rendered as HTML above the chart surface. Include it to show the legend; omit it and none shows. With `isClickable`, each entry toggles selection of its series.
 
 <ApiTable>
   <ApiRow name="variant" type='"square" | "circle" | "circle-outline" | "rounded-square" | "rounded-square-outline" | "vertical-bar" | "horizontal-bar"'>

--- a/src/content/docs/echarts/pie-chart/static.mdx
+++ b/src/content/docs/echarts/pie-chart/static.mdx
@@ -118,15 +118,21 @@ const chartConfig = {
 </EChartsPieChart>
 ```
 
-The one real difference is under the hood: ECharts renders to a `<canvas>`, so these children never mount as DOM. The root reads their props and compiles them into the ECharts option — same JSX, same presence semantics (omit a part and it won't render), same behavior, just declarative config instead of live DOM nodes.
+The difference is under the hood: these compound children are declarative configuration slots rather than visual React DOM nodes. The root reads their props and compiles an ECharts option, which ECharts paints with Canvas by default or SVG when `renderer="svg"`.
 
 The `config` is the same contract as every EvilCharts chart — each key maps a sector name to a `label` and a per-theme `colors` array. See <Link href="/docs/chart-config">Chart Config</Link> for the full shape. Colors resolve from your CSS variables at runtime, so dark mode works with no extra wiring.
 
 <Alert>
   <AlertContent>
-    Canvas rendering brings a few small departures from the Recharts twin: per-sector gradients paint across each sector's own bounding box, sector gaps are constant-width background borders (parallel-edged from rim to center, not a wedge-shaped angular pad), and the `<Background>` pattern is an SVG layer behind the transparent canvas.
+    The ECharts implementation brings a few small departures from the Recharts twin: per-sector gradients paint across each sector's own bounding box, sector gaps are constant-width background borders (parallel-edged from rim to center, not a wedge-shaped angular pad), and the `<Background>` pattern is a separate SVG layer behind the transparent ECharts surface.
   </AlertContent>
 </Alert>
+
+### SVG Renderer
+
+Pass `renderer="svg"` to the chart root to opt into ECharts' SVG renderer. Omit it to use the default Canvas renderer.
+
+<ComponentPreview title='renderer="svg"' name="ex-svg-renderer-echarts-pie-chart" />
 
 ### Interactive Selection
 
@@ -214,7 +220,7 @@ Examples of the pie chart in different configurations. Customize `innerRadius`, 
 
 ## API Reference
 
-The chart has several parts; the props below are grouped by part. On canvas each part is declarative config the root compiles, but the API mirrors the Recharts twin one-to-one.
+The chart has several parts; the props below are grouped by part. Regardless of renderer, each part is declarative config the root compiles, but the API mirrors the Recharts twin one-to-one.
 
 <ApiHeading>EChartsPieChart</ApiHeading>
 
@@ -239,8 +245,11 @@ The root container. It owns the data, shared selection state, loading skeleton, 
   <ApiRow name="className" type="string">
     Extra CSS classes for the chart container.
   </ApiRow>
+  <ApiRow name="renderer" type='"canvas" | "svg"' default='"canvas"'>
+    Rendering engine used by ECharts. Use `"svg"` for an SVG-backed chart surface; omit the prop to keep the Canvas default.
+  </ApiRow>
   <ApiRow name="animation" type="boolean" default="true">
-    Master switch for the intro draw-in. Pass `false` to render instantly. Not on the Recharts twin — it's the canvas off-switch. The OS reduce-motion preference disables the entrance automatically.
+    Master switch for the intro draw-in. Pass `false` to render instantly. Not on the Recharts twin — it's the ECharts off-switch. The OS reduce-motion preference disables the entrance automatically.
   </ApiRow>
   <ApiRow name="defaultSelectedSector" type="string | null" default="null">
     The sector selected on first render.
@@ -327,7 +336,7 @@ The hover tooltip. Its presence enables the tooltip; omit it and none shows. Hid
 
 <ApiHeading>Legend</ApiHeading>
 
-The sector legend, rendered as HTML over the canvas. Its presence enables the legend; omit it and none shows. When `isClickable` is set, each entry toggles selection of its sector.
+The sector legend, rendered as HTML over the chart surface. Its presence enables the legend; omit it and none shows. When `isClickable` is set, each entry toggles selection of its sector.
 
 <ApiTable>
   <ApiRow name="variant" type='"square" | "circle" | "circle-outline" | "rounded-square" | "rounded-square-outline" | "vertical-bar" | "horizontal-bar"'>

--- a/src/content/docs/echarts/radar-chart/static.mdx
+++ b/src/content/docs/echarts/radar-chart/static.mdx
@@ -127,15 +127,21 @@ const chartConfig = {
 </EChartsRadarChart>
 ```
 
-The one difference from the Recharts twin is under the hood: ECharts renders to a `<canvas>`, so these children never mount as DOM. The root reads their props and compiles them into the ECharts option — same JSX, same presence semantics (omit a part and it doesn't render), same behavior, only the children are declarative config rather than live DOM nodes.
+The difference from the Recharts twin is under the hood: these compound children are declarative configuration slots rather than visual React DOM nodes. The root reads their props and compiles an ECharts option, which ECharts paints with Canvas by default or SVG when `renderer="svg"`.
 
 The `config` is the same contract as every EvilCharts chart — each key maps a data key to a `label` and a per-theme `colors` array. See <Link href="/docs/chart-config">Chart Config</Link> for the full shape. Colors resolve from your CSS variables at runtime, so dark mode just works.
 
 <Alert>
   <AlertContent>
-    Canvas rendering brings two small departures from the Recharts twin: a radar series is a single polygon, so multi-color configs paint the stroke and fill as gradients while the vertex dots take one representative color; and the tooltip is item-triggered, showing the hovered series and its per-category values rather than anchoring on a category.
+    The ECharts implementation brings two small departures from the Recharts twin: a radar series is a single polygon, so multi-color configs paint the stroke and fill as gradients while the vertex dots take one representative color; and the tooltip is item-triggered, showing the hovered series and its per-category values rather than anchoring on a category.
   </AlertContent>
 </Alert>
+
+### SVG Renderer
+
+Pass `renderer="svg"` to the chart root to opt into ECharts' SVG renderer. Omit it to use the default Canvas renderer.
+
+<ComponentPreview title='renderer="svg"' name="ex-svg-renderer-echarts-radar-chart" />
 
 ### Interactive Selection
 
@@ -210,7 +216,7 @@ Radar charts with different configurations.
 
 ## API Reference
 
-The radar chart is a root container plus composible parts. On canvas each part is declarative config the root compiles, but the API mirrors the Recharts twin. Each is documented below.
+The radar chart is a root container plus composible parts. Regardless of renderer, each part is declarative config the root compiles, but the API mirrors the Recharts twin. Each is documented below.
 
 <ApiHeading>EChartsRadarChart</ApiHeading>
 
@@ -228,6 +234,9 @@ The root container. It owns the data, shared selection state, loading skeleton, 
   </ApiRow>
   <ApiRow name="className" type="string">
     Additional CSS classes for the chart container.
+  </ApiRow>
+  <ApiRow name="renderer" type='"canvas" | "svg"' default='"canvas"'>
+    Rendering engine used by ECharts. Use `"svg"` for an SVG-backed chart surface; omit the prop to keep the Canvas default.
   </ApiRow>
   <ApiRow name="animation" type="boolean" default="true">
     Master switch for the intro draw-in — the radar polygon grows from the center on first render. Pass `false` to render instantly. The OS reduce-motion preference disables it automatically.
@@ -307,7 +316,7 @@ The radial value axis — the scale running from the center outward. Its presenc
 
 <ApiHeading>Tooltip</ApiHeading>
 
-The hover tooltip. Its presence enables the tooltip; omit it and none shows. On canvas the tooltip is item-triggered — it shows the hovered series and its value at each category, and dims its content when another series is selected.
+The hover tooltip. Its presence enables the tooltip; omit it and none shows. The tooltip is item-triggered — it shows the hovered series and its value at each category, and dims its content when another series is selected.
 
 <ApiTable>
   <ApiRow name="variant" type='"default" | "frosted-glass"' default='"default"'>
@@ -326,7 +335,7 @@ The hover tooltip. Its presence enables the tooltip; omit it and none shows. On 
 
 <ApiHeading>Legend</ApiHeading>
 
-The series legend, rendered as HTML above the canvas. Its presence enables the legend; omit it and none shows. When `isClickable` is set, each entry toggles selection of its series. Hidden automatically while the chart is loading.
+The series legend, rendered as HTML above the chart surface. Its presence enables the legend; omit it and none shows. When `isClickable` is set, each entry toggles selection of its series. Hidden automatically while the chart is loading.
 
 <ApiTable>
   <ApiRow name="variant" type='"square" | "circle" | "circle-outline" | "rounded-square" | "rounded-square-outline" | "vertical-bar" | "horizontal-bar"'>

--- a/src/content/docs/echarts/radar-chart/static.mdx
+++ b/src/content/docs/echarts/radar-chart/static.mdx
@@ -88,7 +88,7 @@ links:
 
 ## Usage
 
-The ECharts radar chart is composible, sharing the Recharts twin's API shape. `<EChartsRadarChart>` is the container, and every part hangs off it as a compound member — `<EChartsRadarChart.PolarGrid>`, `<EChartsRadarChart.PolarAngleAxis>`, `<EChartsRadarChart.PolarRadiusAxis>`, `<EChartsRadarChart.Legend>`, `<EChartsRadarChart.Tooltip>`, and one or more `<EChartsRadarChart.Radar>` — so a single import gives you the whole chart. Each `<Radar>` carries its own `variant` and `isClickable`, so one chart can mix fill styles and make only some series interactive.
+The ECharts radar chart is composable, sharing the Recharts twin's API shape. `<EChartsRadarChart>` is the container, and every part hangs off it as a compound member — `<EChartsRadarChart.PolarGrid>`, `<EChartsRadarChart.PolarAngleAxis>`, `<EChartsRadarChart.PolarRadiusAxis>`, `<EChartsRadarChart.Legend>`, `<EChartsRadarChart.Tooltip>`, and one or more `<EChartsRadarChart.Radar>` — so a single import gives you the whole chart. Each `<Radar>` carries its own `variant` and `isClickable`, so one chart can mix fill styles and make only some series interactive.
 
 ```tsx
 import { EChartsRadarChart, type ChartConfig } from "@/components/evilcharts/charts/echarts-radar-chart";
@@ -216,7 +216,7 @@ Radar charts with different configurations.
 
 ## API Reference
 
-The radar chart is a root container plus composible parts. Regardless of renderer, each part is declarative config the root compiles, but the API mirrors the Recharts twin. Each is documented below.
+The radar chart is a root container plus composable parts. Regardless of renderer, each part is declarative config the root compiles, but the API mirrors the Recharts twin. Each is documented below.
 
 <ApiHeading>EChartsRadarChart</ApiHeading>
 

--- a/src/content/docs/echarts/radial-chart/static.mdx
+++ b/src/content/docs/echarts/radial-chart/static.mdx
@@ -116,15 +116,21 @@ const chartConfig = {
 </EChartsRadialChart>
 ```
 
-The one real difference is under the hood: ECharts renders each ring as a polar `bar` series on a `<canvas>`, so these children never mount as DOM. The root reads their props and compiles them into the ECharts option — same JSX, same presence semantics (omit a part and it doesn't render), same behavior, just declarative config instead of live DOM nodes.
+The difference is under the hood: these compound children are declarative configuration slots rather than visual React DOM nodes. The root reads their props and compiles each ring into an ECharts polar `bar` series, which ECharts paints with Canvas by default or SVG when `renderer="svg"`.
 
 The `config` is the same contract as every EvilCharts chart — each key matches a `nameKey` value and maps it to a `label` and a per-theme `colors` array. See <Link href="/docs/chart-config">Chart Config</Link> for the full shape. Colors resolve from your CSS variables at runtime, so dark mode just works.
 
 <Alert>
   <AlertContent>
-    Canvas rendering brings a few small departures from the Recharts twin: multi-color bars use a diagonal canvas gradient (visually equivalent), and corner rounding becomes a rounded cap on each ring's ends.
+    The ECharts implementation brings a few small departures from the Recharts twin: multi-color bars use a diagonal ECharts gradient, and corner rounding becomes a rounded cap on each ring's ends.
   </AlertContent>
 </Alert>
+
+### SVG Renderer
+
+Pass `renderer="svg"` to the chart root to opt into ECharts' SVG renderer. Omit it to use the default Canvas renderer.
+
+<ComponentPreview title='renderer="svg"' name="ex-svg-renderer-echarts-radial-chart" />
 
 ### Interactive Selection
 
@@ -177,7 +183,7 @@ Radial chart examples with different configurations. Customize `variant`, `inner
 
 ## API Reference
 
-The chart is composed of several parts; the props below are grouped by part. On canvas each part is declarative config the root compiles, but the API mirrors the Recharts twin one-to-one.
+The chart is composed of several parts; the props below are grouped by part. Regardless of renderer, each part is declarative config the root compiles, but the API mirrors the Recharts twin one-to-one.
 
 <ApiHeading>EChartsRadialChart</ApiHeading>
 
@@ -198,6 +204,9 @@ The root container. It owns the data, shared selection state, loading skeleton, 
   </ApiRow>
   <ApiRow name="className" type="string">
     Additional CSS classes for the chart container.
+  </ApiRow>
+  <ApiRow name="renderer" type='"canvas" | "svg"' default='"canvas"'>
+    Rendering engine used by ECharts. Use `"svg"` for an SVG-backed chart surface; omit the prop to keep the Canvas default.
   </ApiRow>
   <ApiRow name="variant" type='"full" | "semi"' default='"full"'>
     The chart's arc shape. `"full"` is a full circle (360°); `"semi"` is a half circle (180°).
@@ -237,7 +246,7 @@ The radial bar series. Each data row becomes one concentric ring. Its presence r
     Data key used for bar values (numbers that set each bar's arc length).
   </ApiRow>
   <ApiRow name="cornerRadius" type="number" default="5">
-    The corner rounding for each bar. On canvas this maps to a rounded cap on the bar's ends — pass `0` for square ends.
+    The corner rounding for each bar. ECharts maps this to a rounded cap on the bar's ends — pass `0` for square ends.
   </ApiRow>
   <ApiRow name="barSize" type="number" default="14">
     Thickness of each bar, in pixels.
@@ -271,7 +280,7 @@ The hover tooltip, labeling each bar by name. Its presence enables the tooltip; 
 
 <ApiHeading>Legend</ApiHeading>
 
-The bar legend, rendered as HTML alongside the canvas. Its presence enables the legend; omit it and none shows. With `isClickable`, each entry toggles selection of its bar.
+The bar legend, rendered as HTML alongside the chart surface. Its presence enables the legend; omit it and none shows. With `isClickable`, each entry toggles selection of its bar.
 
 <ApiTable>
   <ApiRow name="variant" type='"square" | "circle" | "circle-outline" | "rounded-square" | "rounded-square-outline" | "vertical-bar" | "horizontal-bar"'>

--- a/src/content/docs/echarts/sankey-chart/static.mdx
+++ b/src/content/docs/echarts/sankey-chart/static.mdx
@@ -114,18 +114,24 @@ const chartConfig = {
 </EChartsSankeyChart>
 ```
 
-The one real difference is under the hood: ECharts renders to a `<canvas>`, so these children never mount as DOM. The root reads their props and compiles them into the ECharts option — same JSX, same presence semantics, same behavior, but the children are declarative config, not live DOM nodes.
+The difference is under the hood: these compound children are declarative configuration slots rather than visual React DOM nodes. The root reads their props and compiles an ECharts option, which ECharts paints with Canvas by default or SVG when `renderer="svg"`.
 
 `config` is the same contract as every EvilCharts chart — each key maps a node name to a `label` and a per-theme `colors` array. See <Link href="/docs/chart-config">Chart Config</Link> for the full shape. Colors resolve from CSS variables at runtime, so dark mode just works.
 
 <Alert>
   <AlertContent>
-    Canvas rendering brings a few small departures from the Recharts twin: node
+    The ECharts implementation brings a few small departures from the Recharts twin: node
     icons are not rendered, and `verticalPadding` on `<Link>` has no ECharts
     equivalent (see the API notes). All link variants — `gradient`, `solid`,
     `source`, and `target` — are supported.
   </AlertContent>
 </Alert>
+
+### SVG Renderer
+
+Pass `renderer="svg"` to the chart root to opt into ECharts' SVG renderer. Omit it to use the default Canvas renderer.
+
+<ComponentPreview title='renderer="svg"' name="ex-svg-renderer-echarts-sankey-chart" />
 
 ### Interactive Selection
 
@@ -219,7 +225,7 @@ Examples of the sankey chart in different configurations. Customize the `<Link>`
 
 ## API Reference
 
-A root container plus a small set of composible parts. Render the root, then compose the parts you need as children. On canvas each part is declarative config the root compiles, but the API closely mirrors the Recharts twin.
+A root container plus a small set of composible parts. Render the root, then compose the parts you need as children. Regardless of renderer, each part is declarative config the root compiles, but the API closely mirrors the Recharts twin.
 
 <ApiHeading>EChartsSankeyChart</ApiHeading>
 
@@ -227,7 +233,7 @@ The root container. It owns the flow data, shared selection state, loading skele
 
 <ApiTable>
   <ApiRow name="data" type="SankeyData" required>
-    Nodes and links for the flow. `SankeyData` is `{ nodes: SankeyNode[]; links: SankeyLink[] }`, where `SankeyNode = { name: string; icon?: ReactNode }` and `SankeyLink = { source: number; target: number; value: number }`. `source`/`target` are indices into `nodes`. (`icon` is accepted for parity with the Recharts shape but not rendered on canvas.)
+    Nodes and links for the flow. `SankeyData` is `{ nodes: SankeyNode[]; links: SankeyLink[] }`, where `SankeyNode = { name: string; icon?: ReactNode }` and `SankeyLink = { source: number; target: number; value: number }`. `source`/`target` are indices into `nodes`. (`icon` is accepted for parity with the Recharts shape but is not rendered by the ECharts provider.)
   </ApiRow>
   <ApiRow name="config" type="ChartConfig" required>
     Defines the chart's nodes. Each key matches a node name, with a `label` and a per-theme `colors` array. Same contract as every EvilCharts chart — see <Link href="/docs/chart-config">Chart Config</Link>.
@@ -237,6 +243,9 @@ The root container. It owns the flow data, shared selection state, loading skele
   </ApiRow>
   <ApiRow name="className" type="string">
     Additional CSS classes for the chart container.
+  </ApiRow>
+  <ApiRow name="renderer" type='"canvas" | "svg"' default='"canvas"'>
+    Rendering engine used by ECharts. Use `"svg"` for an SVG-backed chart surface; omit the prop to keep the Canvas default.
   </ApiRow>
   <ApiRow name="nodeWidth" type="number" default="10">
     The width of each node in pixels.

--- a/src/content/docs/echarts/ui/brush.mdx
+++ b/src/content/docs/echarts/ui/brush.mdx
@@ -66,7 +66,7 @@ const [range, setRange] = useState({ startIndex: 0, endIndex: data.length - 1 })
 
 ## How It Differs from Recharts
 
-Same JSX, same props, same behavior — but ECharts renders to a `<canvas>`, so the brush is built differently underneath. The miniature is a real second ECharts grid holding mirrored copies of every series. A fully transparent native `dataZoom` slider sits on top of it and supplies the drag interaction, while everything you actually see — the rounded selection frame, the dimmed sides, the grip-dot handle pills, and the range labels — is drawn as canvas elements that track the selection directly.
+Same JSX, same props, same behavior — but the ECharts brush is built differently underneath. The miniature is a real second ECharts grid holding mirrored copies of every series. A fully transparent native `dataZoom` slider sits on top of it and supplies the drag interaction, while the active renderer — Canvas by default or SVG when `renderer="svg"` is set on the chart root — draws the rounded selection frame, dimmed sides, grip-dot handle pills, and range labels that track the selection directly.
 
 The practical differences: the main plot gains drag-to-pan for free, and the footer is a close reconstruction of the Recharts `EvilBrush` rather than a pixel-identical copy of it.
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -45,11 +45,12 @@ Reach for it by default: product dashboards, marketing pages, anything where the
 
 ### ECharts
 
-**Canvas, built for scale.** The ECharts provider draws the same components onto a single canvas, so the point count stops being a DOM problem.
+**Canvas by default, SVG when you need it.** The ECharts provider draws the same components with Canvas for scale, or on an SVG-backed chart surface when you pass `renderer="svg"` to a chart root.
 
-- **Dense data stays smooth.** Thousands of points are pixels, not thousands of nodes.
+- **Dense data stays smooth.** With the default Canvas renderer, thousands of points are pixels, not thousands of nodes.
 - **Built for live data.** Frequent updates and zooming don't fight the browser's layout engine.
-- **Same look.** The variants, glows and entrance animations are ported, not approximated — canvas gradients and pattern tiles doing what the SVG defs do.
+- **Renderer per chart.** Keep Canvas for dense, frequently updated data, or select ECharts' SVG renderer without changing the compound API.
+- **Same look.** The variants, glows, and entrance animations are ported across ECharts renderers using renderer-aware gradients and patterns.
 
 Reach for it when the data outgrows the DOM: long time series, high-frequency updates, dashboards that keep drawing while people interact with them.
 

--- a/src/globals/constants/providers.ts
+++ b/src/globals/constants/providers.ts
@@ -39,7 +39,7 @@ export const PROVIDER_META: Record<Provider, ProviderMeta> = {
   echarts: {
     id: "echarts",
     name: "ECharts",
-    tagline: "Canvas · built for scale",
+    tagline: "Canvas + SVG · built for scale",
     available: false,
   },
 };

--- a/src/registry/__index__.tsx
+++ b/src/registry/__index__.tsx
@@ -529,6 +529,24 @@ export const Index: Record<string, any> = {
     categories: undefined,
     meta: undefined,
   },
+  "ex-svg-renderer-echarts-area-chart": {
+    name: "ex-svg-renderer-echarts-area-chart",
+    description: "",
+    type: "registry:block",
+    registryDependencies: ["@evilcharts/echarts-area-chart"],
+    files: [{
+      path: "@/registry/examples/echarts/ex-svg-renderer-echarts-area-chart.tsx",
+      type: "registry:block",
+      target: ""
+    }],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/examples/echarts/ex-svg-renderer-echarts-area-chart.tsx")
+      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: undefined,
+    meta: undefined,
+  },
   "ex-brush-echarts-area-chart": {
     name: "ex-brush-echarts-area-chart",
     description: "",
@@ -919,6 +937,24 @@ export const Index: Record<string, any> = {
     }],
     component: React.lazy(async () => {
       const mod = await import("@/registry/examples/echarts/ex-echarts-line-chart.tsx")
+      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: undefined,
+    meta: undefined,
+  },
+  "ex-svg-renderer-echarts-line-chart": {
+    name: "ex-svg-renderer-echarts-line-chart",
+    description: "",
+    type: "registry:block",
+    registryDependencies: ["@evilcharts/echarts-line-chart"],
+    files: [{
+      path: "@/registry/examples/echarts/ex-svg-renderer-echarts-line-chart.tsx",
+      type: "registry:block",
+      target: ""
+    }],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/examples/echarts/ex-svg-renderer-echarts-line-chart.tsx")
       const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
       return { default: mod.default || mod[exportName] }
     }),
@@ -1375,6 +1411,24 @@ export const Index: Record<string, any> = {
     categories: undefined,
     meta: undefined,
   },
+  "ex-svg-renderer-echarts-bar-chart": {
+    name: "ex-svg-renderer-echarts-bar-chart",
+    description: "",
+    type: "registry:block",
+    registryDependencies: ["@evilcharts/echarts-bar-chart"],
+    files: [{
+      path: "@/registry/examples/echarts/ex-svg-renderer-echarts-bar-chart.tsx",
+      type: "registry:block",
+      target: ""
+    }],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/examples/echarts/ex-svg-renderer-echarts-bar-chart.tsx")
+      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: undefined,
+    meta: undefined,
+  },
   "ex-buffer-echarts-bar-chart": {
     name: "ex-buffer-echarts-bar-chart",
     description: "",
@@ -1789,6 +1843,24 @@ export const Index: Record<string, any> = {
     categories: undefined,
     meta: undefined,
   },
+  "ex-svg-renderer-echarts-composed-chart": {
+    name: "ex-svg-renderer-echarts-composed-chart",
+    description: "",
+    type: "registry:block",
+    registryDependencies: ["@evilcharts/echarts-composed-chart"],
+    files: [{
+      path: "@/registry/examples/echarts/ex-svg-renderer-echarts-composed-chart.tsx",
+      type: "registry:block",
+      target: ""
+    }],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/examples/echarts/ex-svg-renderer-echarts-composed-chart.tsx")
+      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: undefined,
+    meta: undefined,
+  },
   "ex-gradient-colors-echarts-composed-chart": {
     name: "ex-gradient-colors-echarts-composed-chart",
     description: "",
@@ -2023,6 +2095,24 @@ export const Index: Record<string, any> = {
     categories: undefined,
     meta: undefined,
   },
+  "ex-svg-renderer-echarts-radar-chart": {
+    name: "ex-svg-renderer-echarts-radar-chart",
+    description: "",
+    type: "registry:block",
+    registryDependencies: ["@evilcharts/echarts-radar-chart"],
+    files: [{
+      path: "@/registry/examples/echarts/ex-svg-renderer-echarts-radar-chart.tsx",
+      type: "registry:block",
+      target: ""
+    }],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/examples/echarts/ex-svg-renderer-echarts-radar-chart.tsx")
+      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: undefined,
+    meta: undefined,
+  },
   "ex-lines-variant-echarts-radar-chart": {
     name: "ex-lines-variant-echarts-radar-chart",
     description: "",
@@ -2107,6 +2197,24 @@ export const Index: Record<string, any> = {
     }],
     component: React.lazy(async () => {
       const mod = await import("@/registry/examples/echarts/ex-echarts-pie-chart.tsx")
+      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: undefined,
+    meta: undefined,
+  },
+  "ex-svg-renderer-echarts-pie-chart": {
+    name: "ex-svg-renderer-echarts-pie-chart",
+    description: "",
+    type: "registry:block",
+    registryDependencies: ["@evilcharts/echarts-pie-chart"],
+    files: [{
+      path: "@/registry/examples/echarts/ex-svg-renderer-echarts-pie-chart.tsx",
+      type: "registry:block",
+      target: ""
+    }],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/examples/echarts/ex-svg-renderer-echarts-pie-chart.tsx")
       const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
       return { default: mod.default || mod[exportName] }
     }),
@@ -2257,6 +2365,24 @@ export const Index: Record<string, any> = {
     categories: undefined,
     meta: undefined,
   },
+  "ex-svg-renderer-echarts-radial-chart": {
+    name: "ex-svg-renderer-echarts-radial-chart",
+    description: "",
+    type: "registry:block",
+    registryDependencies: ["@evilcharts/echarts-radial-chart"],
+    files: [{
+      path: "@/registry/examples/echarts/ex-svg-renderer-echarts-radial-chart.tsx",
+      type: "registry:block",
+      target: ""
+    }],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/examples/echarts/ex-svg-renderer-echarts-radial-chart.tsx")
+      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: undefined,
+    meta: undefined,
+  },
   "ex-semi-variant-echarts-radial-chart": {
     name: "ex-semi-variant-echarts-radial-chart",
     description: "",
@@ -2323,6 +2449,24 @@ export const Index: Record<string, any> = {
     }],
     component: React.lazy(async () => {
       const mod = await import("@/registry/examples/echarts/ex-echarts-sankey-chart.tsx")
+      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: undefined,
+    meta: undefined,
+  },
+  "ex-svg-renderer-echarts-sankey-chart": {
+    name: "ex-svg-renderer-echarts-sankey-chart",
+    description: "",
+    type: "registry:block",
+    registryDependencies: ["@evilcharts/echarts-sankey-chart"],
+    files: [{
+      path: "@/registry/examples/echarts/ex-svg-renderer-echarts-sankey-chart.tsx",
+      type: "registry:block",
+      target: ""
+    }],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/examples/echarts/ex-svg-renderer-echarts-sankey-chart.tsx")
       const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
       return { default: mod.default || mod[exportName] }
     }),

--- a/src/registry/charts/echarts-area-chart.tsx
+++ b/src/registry/charts/echarts-area-chart.tsx
@@ -1,6 +1,18 @@
 "use client";
 
 import {
+  DEFAULT_ECHARTS_RENDERER,
+  buildChartCss,
+  flattenColor,
+  getColorsCount,
+  resolveColors,
+  seriesPaint,
+  withAlpha,
+  type ChartConfig,
+  type EChartsRenderer,
+  type ResolvedColors,
+} from "@/registry/ui/echarts-chart";
+import {
   tooltipBaseOption,
   tooltipIndicatorHtml,
   tooltipRow,
@@ -27,16 +39,6 @@ import {
   type TooltipComponentOption,
 } from "echarts/components";
 import {
-  buildChartCss,
-  flattenColor,
-  getColorsCount,
-  resolveColors,
-  seriesPaint,
-  withAlpha,
-  type ChartConfig,
-  type ResolvedColors,
-} from "@/registry/ui/echarts-chart";
-import {
   Children,
   isValidElement,
   useCallback,
@@ -54,7 +56,6 @@ import { LegendOverlay, type LegendVariant } from "@/registry/ui/echarts-legend"
 import type { ComposeOption, ImagePatternObject } from "echarts/core";
 import { LineChart, type LineSeriesOption } from "echarts/charts";
 import { motion, useReducedMotion } from "motion/react";
-import { CanvasRenderer } from "echarts/renderers";
 import * as echarts from "echarts/core";
 
 // Re-export the shared types that were previously declared inline here, so
@@ -62,6 +63,7 @@ import * as echarts from "echarts/core";
 export type {
   ChartConfig,
   DotVariant,
+  EChartsRenderer,
   LegendVariant,
   TooltipPosition,
   TooltipRoundness,
@@ -72,7 +74,7 @@ export type {
 // `DataZoomComponent` bundles both the slider (brush footer) and inside (wheel/drag)
 // zoom. The brush's frame/handles/labels are raw zrender elements, not the
 // graphic component — see syncBrushOverlay.
-echarts.use([LineChart, GridComponent, TooltipComponent, DataZoomComponent, CanvasRenderer]);
+echarts.use([LineChart, GridComponent, TooltipComponent, DataZoomComponent]);
 
 type EChartsInstance = ReturnType<typeof echarts.init>;
 
@@ -165,6 +167,7 @@ export type CurveType =
 export interface EChartsAreaChartProps<TData extends Record<string, unknown>> {
   data: TData[]; // rows rendered by the chart
   config: ChartConfig; // series colors + labels
+  renderer?: EChartsRenderer; // rendering engine — defaults to canvas
   xDataKey?: keyof TData & string; // x category key — falls back to the <XAxis> dataKey / first free column
   className?: string; // extra classes for the chart container
   curveType?: CurveType; // default curve interpolation each <Area> inherits
@@ -1534,6 +1537,7 @@ type LiveState = {
 export function EChartsAreaChart<TData extends Record<string, unknown>>({
   data,
   config,
+  renderer = DEFAULT_ECHARTS_RENDERER,
   xDataKey,
   className,
   curveType = "linear",
@@ -1850,13 +1854,22 @@ export function EChartsAreaChart<TData extends Record<string, unknown>>({
     enableHoverReveal,
   ]);
 
-  // ── Init + resize + theme observer (once) ────────────────────────────────────
+  // ── Init + resize + theme observer (per renderer instance) ──────────────────
   useEffect(() => {
     const mount = mountRef.current;
     const container = containerRef.current;
     if (!mount || !container) return;
 
-    const chart = echarts.init(mount);
+    // Pointer state belongs to the renderer instance. A renderer switch disposes
+    // that surface without emitting mouseout/globalout, so do not carry a hover,
+    // reveal slice, or brush-hover treatment into the replacement instance.
+    // Keep brushRange: the selected zoom window should survive the switch.
+    live.hoveredKey = null;
+    live.revealIndex = null;
+    live.brushHover = { inside: false, left: false, right: false };
+    setHoveredDataKey(null);
+
+    const chart = echarts.init(mount, null, { renderer });
     echartsRef.current = chart;
 
     const resizeObserver = new ResizeObserver(() => {
@@ -2115,7 +2128,7 @@ export function EChartsAreaChart<TData extends Record<string, unknown>>({
       live.hasRevealed = false;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [renderer]);
 
   // ── Sync ECharts with props/theme/selection — resolve, build, push ────────────
   useEffect(() => {
@@ -2164,6 +2177,7 @@ export function EChartsAreaChart<TData extends Record<string, unknown>>({
       push(false);
     };
   }, [
+    renderer,
     live,
     buildOption,
     chartOptions,
@@ -2211,7 +2225,7 @@ export function EChartsAreaChart<TData extends Record<string, unknown>>({
       if (delayTimer !== undefined) clearTimeout(delayTimer);
       cancelAnimationFrame(raf);
     };
-  }, [live, areas, hasSelection, isLoading]);
+  }, [renderer, live, areas, hasSelection, isLoading]);
 
   // ── Loading shimmer — rAF sweeps a bright band, regenerating data off-screen ─
   useEffect(() => {
@@ -2270,7 +2284,7 @@ export function EChartsAreaChart<TData extends Record<string, unknown>>({
     };
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
-  }, [live, isLoading, loadingPoints, loadingData]);
+  }, [renderer, live, isLoading, loadingPoints, loadingData]);
 
   // ── Legend overlay position ──────────────────────────────────────────────────
   // Insets match the Recharts legend's breathing room inside the plot frame.

--- a/src/registry/charts/echarts-bar-chart.tsx
+++ b/src/registry/charts/echarts-bar-chart.tsx
@@ -1,6 +1,17 @@
 "use client";
 
 import {
+  DEFAULT_ECHARTS_RENDERER,
+  buildChartCss,
+  flattenColor,
+  getColorsCount,
+  resolveColors,
+  withAlpha,
+  type ChartConfig,
+  type EChartsRenderer,
+  type ResolvedColors,
+} from "@/registry/ui/echarts-chart";
+import {
   tooltipBaseOption,
   tooltipIndicatorHtml,
   tooltipRow,
@@ -39,33 +50,30 @@ import {
   type FC,
   type ReactNode,
 } from "react";
-import {
-  buildChartCss,
-  flattenColor,
-  getColorsCount,
-  resolveColors,
-  withAlpha,
-  type ChartConfig,
-  type ResolvedColors,
-} from "@/registry/ui/echarts-chart";
 import { LegendOverlay, type LegendVariant } from "@/registry/ui/echarts-legend";
 import type { ComposeOption, ImagePatternObject } from "echarts/core";
 import { BarChart, type BarSeriesOption } from "echarts/charts";
 import { sampleGradient } from "@/registry/ui/echarts-dot";
 import { motion, useReducedMotion } from "motion/react";
-import { CanvasRenderer } from "echarts/renderers";
 import * as echarts from "echarts/core";
 
 // Re-export the shared types that were previously declared inline here, so
 // existing consumers/examples keep importing them from the chart module.
-export type { ChartConfig, LegendVariant, TooltipPosition, TooltipRoundness, TooltipVariant };
+export type {
+  ChartConfig,
+  EChartsRenderer,
+  LegendVariant,
+  TooltipPosition,
+  TooltipRoundness,
+  TooltipVariant,
+};
 
 // Modular registration keeps the bundle lean — only the pieces this chart needs.
 // `DataZoomComponent` bundles both the slider (brush footer) and inside (wheel/drag)
 // zoom. The brush's frame/handles/labels are raw zrender elements, not the
 // graphic component — see syncBrushOverlay. No LineChart: the main plot, the
 // loading skeleton, and the brush mini chart are ALL bar series.
-echarts.use([BarChart, GridComponent, TooltipComponent, DataZoomComponent, CanvasRenderer]);
+echarts.use([BarChart, GridComponent, TooltipComponent, DataZoomComponent]);
 
 type EChartsInstance = ReturnType<typeof echarts.init>;
 
@@ -189,6 +197,7 @@ export type BarAnimationType =
 export interface EChartsBarChartProps<TData extends Record<string, unknown>> {
   data: TData[]; // rows rendered by the chart
   config: ChartConfig; // series colors + labels
+  renderer?: EChartsRenderer; // rendering engine — defaults to canvas
   xDataKey?: keyof TData & string; // category key — falls back to the axis dataKey / first free column
   className?: string; // extra classes for the chart container
   stackType?: StackType; // how multiple bars combine
@@ -1420,6 +1429,7 @@ type LiveState = {
 export function EChartsBarChart<TData extends Record<string, unknown>>({
   data,
   config,
+  renderer = DEFAULT_ECHARTS_RENDERER,
   xDataKey,
   className,
   stackType = "default",
@@ -1714,13 +1724,13 @@ export function EChartsBarChart<TData extends Record<string, unknown>>({
     maxHighlightIndex,
   ]);
 
-  // ── Init + resize + theme observer (once) ────────────────────────────────────
+  // ── Init + resize + theme observer (per renderer instance) ──────────────────
   useEffect(() => {
     const mount = mountRef.current;
     const container = containerRef.current;
     if (!mount || !container) return;
 
-    const chart = echarts.init(mount);
+    const chart = echarts.init(mount, null, { renderer });
     echartsRef.current = chart;
 
     const resizeObserver = new ResizeObserver(() => {
@@ -1852,17 +1862,29 @@ export function EChartsBarChart<TData extends Record<string, unknown>>({
       zr.off("globalout", onZrOut);
       resizeObserver.disconnect();
       themeObserver.disconnect();
+      if (live.expandRaf) {
+        cancelAnimationFrame(live.expandRaf);
+        live.expandRaf = 0;
+      }
       chart.dispose();
       echartsRef.current = null;
       // The overlay elements died with the zrender instance.
       live.brushOverlay = null;
+      live.brushHover = { inside: false, left: false, right: false };
+      // Expand progress and layout measurements belong to the disposed painter.
+      // Recompute them for the replacement renderer instead of briefly painting
+      // its first frame with geometry captured from the old surface.
+      live.expand = { key: null, hovered: null, progress: new Map<number, number>() };
+      live.animateExpand = () => {};
+      live.valuePxPerUnit = null;
+      live.barWidthPx = null;
       // The reveal guard belongs to the chart instance it guarded. Without this
       // reset, StrictMode's dev-only mount→unmount→remount plays the entrance on
       // the throwaway instance and the surviving one renders without it.
       live.hasRevealed = false;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [renderer]);
 
   // ── Sync ECharts with props/theme/selection — resolve, build, push ────────────
   useEffect(() => {
@@ -2030,6 +2052,7 @@ export function EChartsBarChart<TData extends Record<string, unknown>>({
       push(false);
     };
   }, [
+    renderer,
     live,
     buildOption,
     chartOptions,
@@ -2057,7 +2080,14 @@ export function EChartsBarChart<TData extends Record<string, unknown>>({
       chart.dispatchAction({ type: "showTip", seriesIndex: 0, dataIndex: index });
     }, 300);
     return () => clearTimeout(timer);
-  }, [tooltipSlot.present, tooltipSlot.defaultIndex, isLoading, data.length, seriesKeys.length]);
+  }, [
+    renderer,
+    tooltipSlot.present,
+    tooltipSlot.defaultIndex,
+    isLoading,
+    data.length,
+    seriesKeys.length,
+  ]);
 
   // ── Loading shimmer — rAF sweeps a bright band across the gray bars ──────────
   useEffect(() => {
@@ -2106,7 +2136,7 @@ export function EChartsBarChart<TData extends Record<string, unknown>>({
     };
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
-  }, [live, isLoading, loadingBars, loadingData]);
+  }, [renderer, live, isLoading, loadingBars, loadingData]);
 
   // ── Legend overlay position ──────────────────────────────────────────────────
   // Insets match the Recharts legend's breathing room inside the plot frame.

--- a/src/registry/charts/echarts-composed-chart.tsx
+++ b/src/registry/charts/echarts-composed-chart.tsx
@@ -1,6 +1,18 @@
 "use client";
 
 import {
+  DEFAULT_ECHARTS_RENDERER,
+  buildChartCss,
+  flattenColor,
+  getColorsCount,
+  resolveColors,
+  seriesPaint,
+  withAlpha,
+  type ChartConfig,
+  type EChartsRenderer,
+  type ResolvedColors,
+} from "@/registry/ui/echarts-chart";
+import {
   tooltipBaseOption,
   tooltipIndicatorHtml,
   tooltipRow,
@@ -27,16 +39,6 @@ import {
   type TooltipComponentOption,
 } from "echarts/components";
 import {
-  buildChartCss,
-  flattenColor,
-  getColorsCount,
-  resolveColors,
-  seriesPaint,
-  withAlpha,
-  type ChartConfig,
-  type ResolvedColors,
-} from "@/registry/ui/echarts-chart";
-import {
   Children,
   isValidElement,
   useCallback,
@@ -54,7 +56,6 @@ import { BarChart, LineChart, type BarSeriesOption, type LineSeriesOption } from
 import { LegendOverlay, type LegendVariant } from "@/registry/ui/echarts-legend";
 import type { ComposeOption, ImagePatternObject } from "echarts/core";
 import { motion, useReducedMotion } from "motion/react";
-import { CanvasRenderer } from "echarts/renderers";
 import * as echarts from "echarts/core";
 
 // Re-export the shared types that were previously declared inline here, so
@@ -62,6 +63,7 @@ import * as echarts from "echarts/core";
 export type {
   ChartConfig,
   DotVariant,
+  EChartsRenderer,
   LegendVariant,
   TooltipPosition,
   TooltipRoundness,
@@ -73,14 +75,7 @@ export type {
 // `DataZoomComponent` bundles both the slider (brush footer) and inside (wheel/
 // drag) zoom; the brush's frame/handles/labels are raw zrender elements, NOT the
 // graphic component (never registered) — see syncBrushOverlay.
-echarts.use([
-  BarChart,
-  LineChart,
-  GridComponent,
-  TooltipComponent,
-  DataZoomComponent,
-  CanvasRenderer,
-]);
+echarts.use([BarChart, LineChart, GridComponent, TooltipComponent, DataZoomComponent]);
 
 type EChartsInstance = ReturnType<typeof echarts.init>;
 
@@ -217,6 +212,7 @@ export type CurveType =
 export interface EChartsComposedChartProps<TData extends Record<string, unknown>> {
   data: TData[]; // rows rendered by the chart
   config: ChartConfig; // series colors + labels for every bar and line
+  renderer?: EChartsRenderer; // rendering engine — defaults to canvas
   xDataKey?: keyof TData & string; // x category key — falls back to the <XAxis> dataKey / first free column
   className?: string; // extra classes for the chart container
   curveType?: CurveType; // default curve interpolation each <Line> inherits
@@ -1412,6 +1408,7 @@ type LiveState = {
 export function EChartsComposedChart<TData extends Record<string, unknown>>({
   data,
   config,
+  renderer = DEFAULT_ECHARTS_RENDERER,
   xDataKey,
   className,
   curveType = "linear",
@@ -1678,13 +1675,13 @@ export function EChartsComposedChart<TData extends Record<string, unknown>>({
     brushHeight,
   ]);
 
-  // ── Init + resize + theme observer (once) ────────────────────────────────────
+  // ── Init + resize + theme observer (per renderer instance) ──────────────────
   useEffect(() => {
     const mount = mountRef.current;
     const container = containerRef.current;
     if (!mount || !container) return;
 
-    const chart = echarts.init(mount);
+    const chart = echarts.init(mount, null, { renderer });
     echartsRef.current = chart;
 
     const resizeObserver = new ResizeObserver(() => {
@@ -1778,13 +1775,14 @@ export function EChartsComposedChart<TData extends Record<string, unknown>>({
       echartsRef.current = null;
       // The overlay elements died with the zrender instance.
       live.brushOverlay = null;
+      live.brushHover = { inside: false, left: false, right: false };
       // The reveal guard belongs to the chart instance it guarded. Without this
       // reset, StrictMode's dev-only mount→unmount→remount plays the entrance on
       // the throwaway instance and the surviving one renders without it.
       live.hasRevealed = false;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [renderer]);
 
   // ── Sync ECharts with props/theme/selection — resolve, build, push ────────────
   useEffect(() => {
@@ -1834,6 +1832,7 @@ export function EChartsComposedChart<TData extends Record<string, unknown>>({
       push(false);
     };
   }, [
+    renderer,
     live,
     buildOption,
     chartOptions,
@@ -1862,9 +1861,11 @@ export function EChartsComposedChart<TData extends Record<string, unknown>>({
 
     return () => {
       clearTimeout(timer);
-      chart.dispatchAction({ type: "hideTip" });
+      // The renderer-init effect is declared first, so its cleanup may already
+      // have disposed this instance during a renderer switch or unmount.
+      if (!chart.isDisposed()) chart.dispatchAction({ type: "hideTip" });
     };
-  }, [live, isLoading, tooltipSlot.present, tooltipSlot.defaultIndex]);
+  }, [renderer, live, isLoading, tooltipSlot.present, tooltipSlot.defaultIndex]);
 
   // ── Animated dashed stroke — rAF sweeps the dash offset while unselected ─────
   useEffect(() => {
@@ -1903,7 +1904,7 @@ export function EChartsComposedChart<TData extends Record<string, unknown>>({
       if (delayTimer !== undefined) clearTimeout(delayTimer);
       cancelAnimationFrame(raf);
     };
-  }, [live, lines, selectedDataKey, isLoading]);
+  }, [renderer, live, lines, selectedDataKey, isLoading]);
 
   // ── Loading shimmer — rAF sweeps a bright clip window across the skeleton ─────
   useEffect(() => {
@@ -1969,7 +1970,7 @@ export function EChartsComposedChart<TData extends Record<string, unknown>>({
     };
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
-  }, [live, isLoading, loadingBars, loadingData, loadingLineData]);
+  }, [renderer, live, isLoading, loadingBars, loadingData, loadingLineData]);
 
   // ── Legend overlay position ──────────────────────────────────────────────────
   // Insets match the Recharts legend's breathing room inside the plot frame.

--- a/src/registry/charts/echarts-line-chart.tsx
+++ b/src/registry/charts/echarts-line-chart.tsx
@@ -1,6 +1,18 @@
 "use client";
 
 import {
+  DEFAULT_ECHARTS_RENDERER,
+  buildChartCss,
+  flattenColor,
+  getColorsCount,
+  resolveColors,
+  seriesPaint,
+  withAlpha,
+  type ChartConfig,
+  type EChartsRenderer,
+  type ResolvedColors,
+} from "@/registry/ui/echarts-chart";
+import {
   tooltipBaseOption,
   tooltipIndicatorHtml,
   tooltipRow,
@@ -27,16 +39,6 @@ import {
   type TooltipComponentOption,
 } from "echarts/components";
 import {
-  buildChartCss,
-  flattenColor,
-  getColorsCount,
-  resolveColors,
-  seriesPaint,
-  withAlpha,
-  type ChartConfig,
-  type ResolvedColors,
-} from "@/registry/ui/echarts-chart";
-import {
   Children,
   isValidElement,
   useCallback,
@@ -59,7 +61,6 @@ import {
 import { LegendOverlay, type LegendVariant } from "@/registry/ui/echarts-legend";
 import { LineChart, type LineSeriesOption } from "echarts/charts";
 import { motion, useReducedMotion } from "motion/react";
-import { CanvasRenderer } from "echarts/renderers";
 import type { ComposeOption } from "echarts/core";
 import * as echarts from "echarts/core";
 
@@ -68,6 +69,7 @@ import * as echarts from "echarts/core";
 export type {
   ChartConfig,
   DotVariant,
+  EChartsRenderer,
   LegendVariant,
   TooltipPosition,
   TooltipRoundness,
@@ -78,7 +80,7 @@ export type {
 // `DataZoomComponent` bundles both the slider (brush footer) and inside (wheel/drag)
 // zoom. The brush's frame/handles/labels are raw zrender elements, not the
 // graphic component — see syncBrushOverlay. No GraphicComponent is registered.
-echarts.use([LineChart, GridComponent, TooltipComponent, DataZoomComponent, CanvasRenderer]);
+echarts.use([LineChart, GridComponent, TooltipComponent, DataZoomComponent]);
 
 type EChartsInstance = ReturnType<typeof echarts.init>;
 
@@ -186,6 +188,7 @@ export type CurveType =
 export interface EChartsLineChartProps<TData extends Record<string, unknown>> {
   data: TData[]; // rows rendered by the chart
   config: ChartConfig; // series colors + labels
+  renderer?: EChartsRenderer; // rendering engine — defaults to canvas
   xDataKey?: keyof TData & string; // x category key — falls back to the <XAxis> dataKey / first free column
   className?: string; // extra classes for the chart container
   curveType?: CurveType; // default curve interpolation each <Line> inherits
@@ -1347,6 +1350,7 @@ type LiveState = {
 export function EChartsLineChart<TData extends Record<string, unknown>>({
   data,
   config,
+  renderer = DEFAULT_ECHARTS_RENDERER,
   xDataKey,
   className,
   curveType = "linear",
@@ -1648,13 +1652,22 @@ export function EChartsLineChart<TData extends Record<string, unknown>>({
     enableHoverReveal,
   ]);
 
-  // ── Init + resize + theme observer (once) ────────────────────────────────────
+  // ── Init + resize + theme observer (per renderer instance) ──────────────────
   useEffect(() => {
     const mount = mountRef.current;
     const container = containerRef.current;
     if (!mount || !container) return;
 
-    const chart = echarts.init(mount);
+    // Pointer state belongs to the renderer instance. A renderer switch disposes
+    // that surface without emitting mouseout/globalout, so do not carry a hover,
+    // reveal slice, or brush-hover treatment into the replacement instance.
+    // Keep brushRange: the selected zoom window should survive the switch.
+    live.hoveredKey = null;
+    live.revealIndex = null;
+    live.brushHover = { inside: false, left: false, right: false };
+    setHoveredDataKey(null);
+
+    const chart = echarts.init(mount, null, { renderer });
     echartsRef.current = chart;
 
     const resizeObserver = new ResizeObserver(() => {
@@ -1869,7 +1882,7 @@ export function EChartsLineChart<TData extends Record<string, unknown>>({
       live.hasRevealed = false;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [renderer]);
 
   // ── Sync ECharts with props/theme/selection — resolve, build, push ────────────
   useEffect(() => {
@@ -1918,6 +1931,7 @@ export function EChartsLineChart<TData extends Record<string, unknown>>({
       push(false);
     };
   }, [
+    renderer,
     live,
     buildOption,
     chartOptions,
@@ -1966,7 +1980,7 @@ export function EChartsLineChart<TData extends Record<string, unknown>>({
       if (delayTimer !== undefined) clearTimeout(delayTimer);
       cancelAnimationFrame(raf);
     };
-  }, [live, lines, hasSelection, isLoading]);
+  }, [renderer, live, lines, hasSelection, isLoading]);
 
   // ── Loading shimmer — rAF sweeps a bright band, regenerating data off-screen ─
   useEffect(() => {
@@ -2023,7 +2037,7 @@ export function EChartsLineChart<TData extends Record<string, unknown>>({
     };
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
-  }, [live, isLoading, loadingPoints, loadingData]);
+  }, [renderer, live, isLoading, loadingPoints, loadingData]);
 
   // ── Legend overlay position ──────────────────────────────────────────────────
   // Insets match the Recharts legend's breathing room inside the plot frame.

--- a/src/registry/charts/echarts-pie-chart.tsx
+++ b/src/registry/charts/echarts-pie-chart.tsx
@@ -11,6 +11,16 @@ import {
   type TooltipVariant,
 } from "@/registry/ui/echarts-tooltip";
 import {
+  DEFAULT_ECHARTS_RENDERER,
+  buildChartCss,
+  getColorsCount,
+  resolveColors,
+  withAlpha,
+  type ChartConfig,
+  type EChartsRenderer,
+  type ResolvedColors,
+} from "@/registry/ui/echarts-chart";
+import {
   Children,
   isValidElement,
   useCallback,
@@ -23,31 +33,29 @@ import {
   type FC,
   type ReactNode,
 } from "react";
-import {
-  buildChartCss,
-  getColorsCount,
-  resolveColors,
-  withAlpha,
-  type ChartConfig,
-  type ResolvedColors,
-} from "@/registry/ui/echarts-chart";
 import { TooltipComponent, type TooltipComponentOption } from "echarts/components";
 import { LegendOverlay, type LegendVariant } from "@/registry/ui/echarts-legend";
 import { PieChart, type PieSeriesOption } from "echarts/charts";
 import { motion, useReducedMotion } from "motion/react";
-import { CanvasRenderer } from "echarts/renderers";
 import type { ComposeOption } from "echarts/core";
 import * as echarts from "echarts/core";
 
 // Re-export the shared types that were previously declared inline here, so
 // existing consumers/examples keep importing them from the chart module.
-export type { ChartConfig, LegendVariant, TooltipPosition, TooltipRoundness, TooltipVariant };
+export type {
+  ChartConfig,
+  EChartsRenderer,
+  LegendVariant,
+  TooltipPosition,
+  TooltipRoundness,
+  TooltipVariant,
+};
 
 // Modular registration keeps the bundle lean — only the pieces this chart needs.
 // A pie has no coordinate system, so there is no GridComponent and no axes; the
 // tooltip is item-triggered. Never register GraphicComponent: the loading shimmer
 // and selection dim are per-sector itemStyle updates, not graphic overlays.
-echarts.use([PieChart, TooltipComponent, CanvasRenderer]);
+echarts.use([PieChart, TooltipComponent]);
 
 type EChartsInstance = ReturnType<typeof echarts.init>;
 
@@ -166,8 +174,9 @@ export interface EChartsPieChartProps<TData extends Record<string, unknown>> {
   dataKey: keyof TData & string; // key holding each sector's numeric value
   nameKey: keyof TData & string; // key holding each sector's name
   className?: string; // extra classes for the chart container
+  renderer?: EChartsRenderer; // rendering engine — canvas by default, or SVG
   // Master switch for the intro draw-in. Not present on the Recharts twin (which
-  // hardcodes its animation); added here as the canvas off-switch, mirroring the
+  // hardcodes its animation); added here as the ECharts off-switch, mirroring the
   // ECharts area chart's `animation` prop. OS reduce-motion also disables it.
   animation?: boolean;
   defaultSelectedSector?: string | null; // sector selected on first render
@@ -873,6 +882,7 @@ export function EChartsPieChart<TData extends Record<string, unknown>>({
   dataKey,
   nameKey,
   className,
+  renderer = DEFAULT_ECHARTS_RENDERER,
   animation = true,
   defaultSelectedSector = null,
   selectedSector: selectedSectorProp,
@@ -907,7 +917,9 @@ export function EChartsPieChart<TData extends Record<string, unknown>>({
 
   // Selection is controlled when the `selectedSector` prop is provided; otherwise
   // the internal state (seeded by defaultSelectedSector) drives it.
-  const [internalSelectedSector, setSelectedSector] = useState<string | null>(defaultSelectedSector);
+  const [internalSelectedSector, setSelectedSector] = useState<string | null>(
+    defaultSelectedSector,
+  );
   const selectedSector =
     selectedSectorProp !== undefined ? selectedSectorProp : internalSelectedSector;
 
@@ -987,13 +999,13 @@ export function EChartsPieChart<TData extends Record<string, unknown>>({
     isLoading,
   ]);
 
-  // ── Init + resize + theme observer (once) ────────────────────────────────────
+  // ── Init + resize + theme observer (per renderer instance) ───────────────────
   useEffect(() => {
     const mount = mountRef.current;
     const container = containerRef.current;
     if (!mount || !container) return;
 
-    const chart = echarts.init(mount);
+    const chart = echarts.init(mount, null, { renderer });
     echartsRef.current = chart;
 
     const resizeObserver = new ResizeObserver(() => {
@@ -1041,7 +1053,7 @@ export function EChartsPieChart<TData extends Record<string, unknown>>({
       live.hasRevealed = false;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [renderer]);
 
   // ── Sync ECharts with props/theme/selection — resolve, build, push ────────────
   useEffect(() => {
@@ -1091,6 +1103,7 @@ export function EChartsPieChart<TData extends Record<string, unknown>>({
     animation,
     shouldReduceMotion,
     config,
+    renderer,
     sectorKeys,
   ]);
 
@@ -1107,7 +1120,7 @@ export function EChartsPieChart<TData extends Record<string, unknown>>({
       });
     });
     return () => cancelAnimationFrame(raf);
-  }, [isLoading, tooltipSlot.present, tooltipSlot.defaultIndex]);
+  }, [isLoading, tooltipSlot.present, tooltipSlot.defaultIndex, renderer]);
 
   // ── Loading shimmer — rAF sweeps a bright window around the ring ──────────────
   useEffect(() => {
@@ -1150,7 +1163,7 @@ export function EChartsPieChart<TData extends Record<string, unknown>>({
     };
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
-  }, [live, isLoading, pie]);
+  }, [live, isLoading, pie, renderer]);
 
   // ── Legend overlay position ──────────────────────────────────────────────────
   const legendStyle: CSSProperties = {

--- a/src/registry/charts/echarts-radar-chart.tsx
+++ b/src/registry/charts/echarts-radar-chart.tsx
@@ -11,6 +11,16 @@ import {
   type TooltipVariant,
 } from "@/registry/ui/echarts-tooltip";
 import {
+  DEFAULT_ECHARTS_RENDERER,
+  buildChartCss,
+  getColorsCount,
+  resolveColors,
+  withAlpha,
+  type ChartConfig,
+  type EChartsRenderer,
+  type ResolvedColors,
+} from "@/registry/ui/echarts-chart";
+import {
   Children,
   isValidElement,
   useCallback,
@@ -24,14 +34,6 @@ import {
   type ReactNode,
 } from "react";
 import {
-  buildChartCss,
-  getColorsCount,
-  resolveColors,
-  withAlpha,
-  type ChartConfig,
-  type ResolvedColors,
-} from "@/registry/ui/echarts-chart";
-import {
   RadarComponent,
   TooltipComponent,
   type RadarComponentOption,
@@ -41,7 +43,6 @@ import { dotStyle, sampleGradient, type DotVariant } from "@/registry/ui/echarts
 import { LegendOverlay, type LegendVariant } from "@/registry/ui/echarts-legend";
 import { RadarChart, type RadarSeriesOption } from "echarts/charts";
 import { motion, useReducedMotion } from "motion/react";
-import { CanvasRenderer } from "echarts/renderers";
 import type { ComposeOption } from "echarts/core";
 import * as echarts from "echarts/core";
 
@@ -50,6 +51,7 @@ import * as echarts from "echarts/core";
 export type {
   ChartConfig,
   DotVariant,
+  EChartsRenderer,
   LegendVariant,
   TooltipPosition,
   TooltipRoundness,
@@ -60,7 +62,7 @@ export type {
 // `RadarComponent` is the polar coordinate system (indicators, rings, spokes);
 // `RadarChart` is the series that draws polygons inside it. No GraphicComponent —
 // this chart has no zrender overlays (the recharts twin has no brush).
-echarts.use([RadarChart, RadarComponent, TooltipComponent, CanvasRenderer]);
+echarts.use([RadarChart, RadarComponent, TooltipComponent]);
 
 type EChartsInstance = ReturnType<typeof echarts.init>;
 
@@ -131,6 +133,7 @@ export interface EChartsRadarChartProps<TData extends Record<string, unknown>> {
   data: TData[]; // rows rendered by the chart — each row is one angle-axis category
   config: ChartConfig; // series colors + labels
   className?: string; // extra classes for the chart container
+  renderer?: EChartsRenderer; // rendering engine — canvas by default, or SVG
   animation?: boolean; // master switch for the intro draw-in — false renders instantly
   defaultSelectedDataKey?: string | null; // series selected on first render
   onSelectionChange?: (key: string | null) => void; // fires when the selected series changes
@@ -779,6 +782,7 @@ export function EChartsRadarChart<TData extends Record<string, unknown>>({
   data,
   config,
   className,
+  renderer = DEFAULT_ECHARTS_RENDERER,
   animation = true,
   defaultSelectedDataKey = null,
   onSelectionChange,
@@ -944,13 +948,13 @@ export function EChartsRadarChart<TData extends Record<string, unknown>>({
     loadingPoints,
   ]);
 
-  // ── Init + resize + theme observer (once) ────────────────────────────────────
+  // ── Init + resize + theme observer (per renderer instance) ───────────────────
   useEffect(() => {
     const mount = mountRef.current;
     const container = containerRef.current;
     if (!mount || !container) return;
 
-    const chart = echarts.init(mount);
+    const chart = echarts.init(mount, null, { renderer });
     echartsRef.current = chart;
 
     const resizeObserver = new ResizeObserver(() => {
@@ -1000,7 +1004,7 @@ export function EChartsRadarChart<TData extends Record<string, unknown>>({
       live.hasRevealed = false;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [renderer]);
 
   // ── Sync ECharts with props/theme/selection — resolve, build, push ────────────
   useEffect(() => {
@@ -1118,6 +1122,7 @@ export function EChartsRadarChart<TData extends Record<string, unknown>>({
     animation,
     shouldReduceMotion,
     config,
+    renderer,
     seriesKeys,
     tooltipSlot.present,
     tooltipSlot.defaultIndex,
@@ -1176,7 +1181,7 @@ export function EChartsRadarChart<TData extends Record<string, unknown>>({
     };
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
-  }, [live, isLoading, loadingPoints, loadingData]);
+  }, [live, isLoading, loadingPoints, loadingData, renderer]);
 
   // ── Legend overlay position ──────────────────────────────────────────────────
   // Insets match the Recharts legend's breathing room inside the plot frame.

--- a/src/registry/charts/echarts-radial-chart.tsx
+++ b/src/registry/charts/echarts-radial-chart.tsx
@@ -11,11 +11,13 @@ import {
   type TooltipVariant,
 } from "@/registry/ui/echarts-tooltip";
 import {
+  DEFAULT_ECHARTS_RENDERER,
   buildChartCss,
   getColorsCount,
   resolveColors,
   withAlpha,
   type ChartConfig,
+  type EChartsRenderer,
   type ResolvedColors,
 } from "@/registry/ui/echarts-chart";
 import {
@@ -39,13 +41,19 @@ import {
 import { LegendIndicator, type LegendVariant } from "@/registry/ui/echarts-legend";
 import { BarChart, type BarSeriesOption } from "echarts/charts";
 import { motion, useReducedMotion } from "motion/react";
-import { CanvasRenderer } from "echarts/renderers";
 import type { ComposeOption } from "echarts/core";
 import * as echarts from "echarts/core";
 
 // Re-export the shared types that were previously declared inline here, so
 // existing consumers/examples keep importing them from the chart module.
-export type { ChartConfig, LegendVariant, TooltipPosition, TooltipRoundness, TooltipVariant };
+export type {
+  ChartConfig,
+  EChartsRenderer,
+  LegendVariant,
+  TooltipPosition,
+  TooltipRoundness,
+  TooltipVariant,
+};
 
 // Modular registration keeps the bundle lean — only the pieces this chart needs.
 // `PolarComponent` bundles the polar coordinate system together with its
@@ -53,7 +61,7 @@ export type { ChartConfig, LegendVariant, TooltipPosition, TooltipRoundness, Too
 // value drives the sweep angle). No GraphicComponent: unlike the area chart's
 // brush, nothing here draws raw zrender overlays — selection is per-datum
 // opacity, and the skeleton shimmer is a swept gradient.
-echarts.use([BarChart, PolarComponent, TooltipComponent, CanvasRenderer]);
+echarts.use([BarChart, PolarComponent, TooltipComponent]);
 
 type EChartsInstance = ReturnType<typeof echarts.init>;
 
@@ -138,6 +146,7 @@ export interface EChartsRadialChartProps<TData extends Record<string, unknown>> 
   config: ChartConfig; // bar colors + labels, keyed by each bar's name
   nameKey: keyof TData & string; // data key holding each bar's name
   className?: string; // extra classes for the chart container
+  renderer?: EChartsRenderer; // rendering engine — canvas by default, or SVG
   variant?: RadialVariant; // arc shape — full circle or half circle
   // Value a full sweep represents. Without it the scale is derived from the data,
   // so the largest bar always fills the arc — set it (e.g. 100) for gauges, where
@@ -879,6 +888,7 @@ export function EChartsRadialChart<TData extends Record<string, unknown>>({
   config,
   nameKey,
   className,
+  renderer = DEFAULT_ECHARTS_RENDERER,
   variant = "full",
   max,
   innerRadius = DEFAULT_INNER_RADIUS,
@@ -1023,13 +1033,13 @@ export function EChartsRadialChart<TData extends Record<string, unknown>>({
     loadingData,
   ]);
 
-  // ── Init + resize + theme observer (once) ────────────────────────────────────
+  // ── Init + resize + theme observer (per renderer instance) ───────────────────
   useEffect(() => {
     const mount = mountRef.current;
     const container = containerRef.current;
     if (!mount || !container) return;
 
-    const chart = echarts.init(mount);
+    const chart = echarts.init(mount, null, { renderer });
     echartsRef.current = chart;
 
     const resizeObserver = new ResizeObserver(() => {
@@ -1072,7 +1082,7 @@ export function EChartsRadialChart<TData extends Record<string, unknown>>({
       live.hasRevealed = false;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [renderer]);
 
   // ── Sync ECharts with props/theme/selection — resolve, build, push ────────────
   useEffect(() => {
@@ -1131,6 +1141,7 @@ export function EChartsRadialChart<TData extends Record<string, unknown>>({
     isLoading,
     shouldReduceMotion,
     config,
+    renderer,
     configKeys,
     tooltipSlot,
   ]);
@@ -1178,11 +1189,11 @@ export function EChartsRadialChart<TData extends Record<string, unknown>>({
     };
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
-  }, [live, isLoading, loadingData]);
+  }, [live, isLoading, loadingData, renderer]);
 
   // ── Legend overlay (HTML) ─────────────────────────────────────────────────────
   // One entry per ring. Unlike the area twin's absolutely-positioned legend, the
-  // top/bottom placements flow above/below the canvas so they RESERVE space —
+  // top/bottom placements flow above/below the plot so they RESERVE space —
   // the polar plot shrinks to fit, matching how Recharts lays the legend out.
   // `middle` overlays, centered.
   const legendJustify =

--- a/src/registry/charts/echarts-sankey-chart.tsx
+++ b/src/registry/charts/echarts-sankey-chart.tsx
@@ -11,11 +11,13 @@ import {
   type TooltipVariant,
 } from "@/registry/ui/echarts-tooltip";
 import {
+  DEFAULT_ECHARTS_RENDERER,
   buildChartCss,
   getColorsCount,
   resolveColors,
   withAlpha,
   type ChartConfig,
+  type EChartsRenderer,
   type ResolvedColors,
 } from "@/registry/ui/echarts-chart";
 import {
@@ -33,19 +35,18 @@ import {
 import { TooltipComponent, type TooltipComponentOption } from "echarts/components";
 import { SankeyChart, type SankeySeriesOption } from "echarts/charts";
 import { motion, useReducedMotion } from "motion/react";
-import { CanvasRenderer } from "echarts/renderers";
 import type { ComposeOption } from "echarts/core";
 import * as echarts from "echarts/core";
 
 // Re-export the shared types that were previously declared inline here, so
 // existing consumers/examples keep importing them from the chart module.
-export type { ChartConfig, TooltipPosition, TooltipRoundness, TooltipVariant };
+export type { ChartConfig, EChartsRenderer, TooltipPosition, TooltipRoundness, TooltipVariant };
 
 // Modular registration keeps the bundle lean — only the pieces this chart needs.
 // A sankey draws its own node/link geometry, so there is no grid, axis, or
 // dataZoom here; the tooltip is the one extra component. GraphicComponent is
 // deliberately NOT registered — this chart adds no raw graphic overlays.
-echarts.use([SankeyChart, TooltipComponent, CanvasRenderer]);
+echarts.use([SankeyChart, TooltipComponent]);
 
 type EChartsInstance = ReturnType<typeof echarts.init>;
 
@@ -175,6 +176,7 @@ export interface EChartsSankeyChartProps {
   config: ChartConfig; // node colors + labels keyed by node name
   children: ReactNode; // composed parts — <Node>, <NodeLabel>, <Link>, <Tooltip>
   className?: string; // extra classes for the chart container
+  renderer?: EChartsRenderer; // rendering engine — canvas by default, or SVG
   nodeWidth?: number; // width of each node in pixels
   nodePadding?: number; // vertical gap between nodes (echarts nodeGap)
   linkCurvature?: number; // link curve amount, 0 (straight) to 1 (maximum)
@@ -1058,6 +1060,7 @@ export function EChartsSankeyChart({
   config,
   children,
   className,
+  renderer = DEFAULT_ECHARTS_RENDERER,
   nodeWidth = DEFAULT_NODE_WIDTH,
   nodePadding = DEFAULT_NODE_PADDING,
   linkCurvature = DEFAULT_LINK_CURVATURE,
@@ -1188,13 +1191,13 @@ export function EChartsSankeyChart({
     outsideLabels,
   ]);
 
-  // ── Init + resize + theme observer (once) ────────────────────────────────────
+  // ── Init + resize + theme observer (per renderer instance) ───────────────────
   useEffect(() => {
     const mount = mountRef.current;
     const container = containerRef.current;
     if (!mount || !container) return;
 
-    const chart = echarts.init(mount);
+    const chart = echarts.init(mount, null, { renderer });
     echartsRef.current = chart;
 
     const resizeObserver = new ResizeObserver(() => {
@@ -1240,7 +1243,7 @@ export function EChartsSankeyChart({
       live.hasRevealed = false;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [renderer]);
 
   // ── Sync ECharts with props/theme/selection — resolve, build, push ────────────
   useEffect(() => {
@@ -1327,6 +1330,7 @@ export function EChartsSankeyChart({
     animationType,
     shouldReduceMotion,
     config,
+    renderer,
     nodeNames,
   ]);
 
@@ -1382,7 +1386,7 @@ export function EChartsSankeyChart({
     };
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
-  }, [live, isLoading]);
+  }, [live, isLoading, renderer]);
 
   return (
     <div

--- a/src/registry/examples/echarts/ex-svg-renderer-echarts-area-chart.tsx
+++ b/src/registry/examples/echarts/ex-svg-renderer-echarts-area-chart.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { EChartsAreaChart, type ChartConfig } from "@/registry/charts/echarts-area-chart";
+
+const data = [
+  { month: "January", visitors: 342 },
+  { month: "February", visitors: 876 },
+  { month: "March", visitors: 512 },
+  { month: "April", visitors: 629 },
+  { month: "May", visitors: 458 },
+  { month: "June", visitors: 781 },
+];
+
+const chartConfig = {
+  visitors: {
+    label: "Visitors",
+    colors: {
+      light: ["#047857"],
+      dark: ["#10b981"],
+    },
+  },
+} satisfies ChartConfig;
+
+export function EChartsSvgRendererAreaChart() {
+  return (
+    <EChartsAreaChart
+      renderer="svg"
+      data={data}
+      config={chartConfig}
+      className="h-full w-full p-4"
+      xDataKey="month"
+    >
+      <EChartsAreaChart.Grid />
+      <EChartsAreaChart.XAxis dataKey="month" tickFormatter={(value) => value.substring(0, 3)} />
+      <EChartsAreaChart.Tooltip />
+      <EChartsAreaChart.Area dataKey="visitors" variant="gradient">
+        <EChartsAreaChart.ActiveDot variant="colored-border" />
+      </EChartsAreaChart.Area>
+      <EChartsAreaChart.Brush />
+    </EChartsAreaChart>
+  );
+}

--- a/src/registry/examples/echarts/ex-svg-renderer-echarts-area-chart.tsx
+++ b/src/registry/examples/echarts/ex-svg-renderer-echarts-area-chart.tsx
@@ -24,7 +24,7 @@ const chartConfig = {
 export function EChartsSvgRendererAreaChart() {
   return (
     <EChartsAreaChart
-      renderer="svg"
+      renderer="svg" // [!code highlight]
       data={data}
       config={chartConfig}
       className="h-full w-full p-4"

--- a/src/registry/examples/echarts/ex-svg-renderer-echarts-bar-chart.tsx
+++ b/src/registry/examples/echarts/ex-svg-renderer-echarts-bar-chart.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { EChartsBarChart, type ChartConfig } from "@/registry/charts/echarts-bar-chart";
+
+const data = [
+  { month: "January", desktop: 342, mobile: 184 },
+  { month: "February", desktop: 876, mobile: 491 },
+  { month: "March", desktop: 512, mobile: 290 },
+  { month: "April", desktop: 629, mobile: 391 },
+  { month: "May", desktop: 458, mobile: 309 },
+  { month: "June", desktop: 781, mobile: 449 },
+  { month: "July", desktop: 394, mobile: 234 },
+  { month: "August", desktop: 925, mobile: 557 },
+  { month: "September", desktop: 647, mobile: 367 },
+  { month: "October", desktop: 532, mobile: 357 },
+  { month: "November", desktop: 803, mobile: 515 },
+  { month: "December", desktop: 271, mobile: 149 },
+];
+
+const chartConfig = {
+  desktop: {
+    label: "Desktop",
+    colors: {
+      light: ["#047857"],
+      dark: ["#10b981"],
+    },
+  },
+  mobile: {
+    label: "Mobile",
+    colors: {
+      light: ["#be123c"],
+      dark: ["#f43f5e"],
+    },
+  },
+} satisfies ChartConfig;
+
+export function EChartsSvgRendererBarChart() {
+  return (
+    <EChartsBarChart
+      renderer="svg"
+      data={data}
+      config={chartConfig}
+      className="h-full w-full p-4"
+      xDataKey="month"
+    >
+      <EChartsBarChart.Grid />
+      <EChartsBarChart.XAxis dataKey="month" tickFormatter={(value) => value.substring(0, 3)} />
+      <EChartsBarChart.Brush formatLabel={(value) => String(value).substring(0, 3)} />
+      <EChartsBarChart.Legend isClickable />
+      <EChartsBarChart.Tooltip />
+      <EChartsBarChart.Bar dataKey="desktop" variant="default" isClickable />
+      <EChartsBarChart.Bar dataKey="mobile" variant="default" isClickable />
+    </EChartsBarChart>
+  );
+}

--- a/src/registry/examples/echarts/ex-svg-renderer-echarts-bar-chart.tsx
+++ b/src/registry/examples/echarts/ex-svg-renderer-echarts-bar-chart.tsx
@@ -37,7 +37,7 @@ const chartConfig = {
 export function EChartsSvgRendererBarChart() {
   return (
     <EChartsBarChart
-      renderer="svg"
+      renderer="svg" // [!code highlight]
       data={data}
       config={chartConfig}
       className="h-full w-full p-4"

--- a/src/registry/examples/echarts/ex-svg-renderer-echarts-composed-chart.tsx
+++ b/src/registry/examples/echarts/ex-svg-renderer-echarts-composed-chart.tsx
@@ -37,7 +37,7 @@ const chartConfig = {
 export function EChartsSvgRendererComposedChart() {
   return (
     <EChartsComposedChart
-      renderer="svg"
+      renderer="svg" // [!code highlight]
       className="h-full w-full p-4"
       xDataKey="month"
       data={data}

--- a/src/registry/examples/echarts/ex-svg-renderer-echarts-composed-chart.tsx
+++ b/src/registry/examples/echarts/ex-svg-renderer-echarts-composed-chart.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { EChartsComposedChart, type ChartConfig } from "@/registry/charts/echarts-composed-chart";
+
+const data = [
+  { month: "January", revenue: 4200, profit: 1800 },
+  { month: "February", revenue: 5800, profit: 2400 },
+  { month: "March", revenue: 4100, profit: 1600 },
+  { month: "April", revenue: 6200, profit: 2800 },
+  { month: "May", revenue: 5400, profit: 2200 },
+  { month: "June", revenue: 7800, profit: 3400 },
+  { month: "July", revenue: 6100, profit: 2600 },
+  { month: "August", revenue: 8200, profit: 3800 },
+  { month: "September", revenue: 5900, profit: 2500 },
+  { month: "October", revenue: 6800, profit: 3000 },
+  { month: "November", revenue: 7200, profit: 3200 },
+  { month: "December", revenue: 9100, profit: 4200 },
+];
+
+const chartConfig = {
+  revenue: {
+    label: "Revenue",
+    colors: {
+      light: ["#3b82f6"],
+      dark: ["#6A5ACD"],
+    },
+  },
+  profit: {
+    label: "Profit",
+    colors: {
+      light: ["#10b981"],
+      dark: ["#34d399"],
+    },
+  },
+} satisfies ChartConfig;
+
+export function EChartsSvgRendererComposedChart() {
+  return (
+    <EChartsComposedChart
+      renderer="svg"
+      className="h-full w-full p-4"
+      xDataKey="month"
+      data={data}
+      config={chartConfig}
+    >
+      <EChartsComposedChart.Grid />
+      <EChartsComposedChart.XAxis
+        dataKey="month"
+        tickFormatter={(value) => value.substring(0, 3)}
+      />
+      <EChartsComposedChart.Brush formatLabel={(value) => String(value).substring(0, 3)} />
+      <EChartsComposedChart.Legend isClickable />
+      <EChartsComposedChart.Tooltip />
+      <EChartsComposedChart.Bar dataKey="revenue" isClickable />
+      <EChartsComposedChart.Line dataKey="profit" isClickable>
+        <EChartsComposedChart.ActiveDot variant="colored-border" />
+        <EChartsComposedChart.Dot variant="default" />
+      </EChartsComposedChart.Line>
+    </EChartsComposedChart>
+  );
+}

--- a/src/registry/examples/echarts/ex-svg-renderer-echarts-line-chart.tsx
+++ b/src/registry/examples/echarts/ex-svg-renderer-echarts-line-chart.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { EChartsLineChart, type ChartConfig } from "@/registry/charts/echarts-line-chart";
+
+const data = [
+  { month: "January", desktop: 342, mobile: 184 },
+  { month: "February", desktop: 876, mobile: 491 },
+  { month: "March", desktop: 512, mobile: 290 },
+  { month: "April", desktop: 629, mobile: 391 },
+  { month: "May", desktop: 458, mobile: 309 },
+  { month: "June", desktop: 781, mobile: 449 },
+  { month: "July", desktop: 394, mobile: 234 },
+  { month: "August", desktop: 925, mobile: 557 },
+  { month: "September", desktop: 647, mobile: 367 },
+  { month: "October", desktop: 532, mobile: 357 },
+  { month: "November", desktop: 803, mobile: 515 },
+  { month: "December", desktop: 271, mobile: 149 },
+];
+
+const chartConfig = {
+  desktop: {
+    label: "Desktop",
+    colors: {
+      light: ["#047857"],
+      dark: ["#10b981"],
+    },
+  },
+  mobile: {
+    label: "Mobile",
+    colors: {
+      light: ["#be123c"],
+      dark: ["#f43f5e"],
+    },
+  },
+} satisfies ChartConfig;
+
+export function EChartsSvgRendererLineChart() {
+  return (
+    <EChartsLineChart
+      renderer="svg"
+      data={data}
+      config={chartConfig}
+      className="h-full w-full p-4"
+      xDataKey="month"
+    >
+      <EChartsLineChart.XAxis dataKey="month" tickFormatter={(value) => value.substring(0, 3)} />
+      <EChartsLineChart.Brush formatLabel={(value) => String(value).substring(0, 3)} />
+      <EChartsLineChart.Legend isClickable />
+      <EChartsLineChart.Tooltip />
+      <EChartsLineChart.Line dataKey="desktop" strokeVariant="solid" isClickable>
+        <EChartsLineChart.Dot variant="border" />
+        <EChartsLineChart.ActiveDot variant="colored-border" />
+      </EChartsLineChart.Line>
+      <EChartsLineChart.Line dataKey="mobile" strokeVariant="solid" isClickable>
+        <EChartsLineChart.Dot variant="border" />
+        <EChartsLineChart.ActiveDot variant="colored-border" />
+      </EChartsLineChart.Line>
+    </EChartsLineChart>
+  );
+}

--- a/src/registry/examples/echarts/ex-svg-renderer-echarts-line-chart.tsx
+++ b/src/registry/examples/echarts/ex-svg-renderer-echarts-line-chart.tsx
@@ -37,7 +37,7 @@ const chartConfig = {
 export function EChartsSvgRendererLineChart() {
   return (
     <EChartsLineChart
-      renderer="svg"
+      renderer="svg" // [!code highlight]
       data={data}
       config={chartConfig}
       className="h-full w-full p-4"

--- a/src/registry/examples/echarts/ex-svg-renderer-echarts-pie-chart.tsx
+++ b/src/registry/examples/echarts/ex-svg-renderer-echarts-pie-chart.tsx
@@ -51,7 +51,7 @@ const chartConfig = {
 export function EChartsSvgRendererPieChart() {
   return (
     <EChartsPieChart
-      renderer="svg"
+      renderer="svg" // [!code highlight]
       className="h-full w-full p-4"
       data={data}
       dataKey="visitors"

--- a/src/registry/examples/echarts/ex-svg-renderer-echarts-pie-chart.tsx
+++ b/src/registry/examples/echarts/ex-svg-renderer-echarts-pie-chart.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { EChartsPieChart, type ChartConfig } from "@/registry/charts/echarts-pie-chart";
+
+const data = [
+  { browser: "chrome", visitors: 275 },
+  { browser: "safari", visitors: 200 },
+  { browser: "firefox", visitors: 187 },
+  { browser: "edge", visitors: 173 },
+  { browser: "other", visitors: 90 },
+];
+
+const chartConfig = {
+  chrome: {
+    label: "Chrome",
+    colors: {
+      light: ["#3b82f6"],
+      dark: ["#60a5fa"],
+    },
+  },
+  safari: {
+    label: "Safari",
+    colors: {
+      light: ["#10b981"],
+      dark: ["#34d399"],
+    },
+  },
+  firefox: {
+    label: "Firefox",
+    colors: {
+      light: ["#f59e0b"],
+      dark: ["#fbbf24"],
+    },
+  },
+  edge: {
+    label: "Edge",
+    colors: {
+      light: ["#8b5cf6"],
+      dark: ["#a78bfa"],
+    },
+  },
+  other: {
+    label: "Other",
+    colors: {
+      light: ["#6b7280"],
+      dark: ["#9ca3af"],
+    },
+  },
+} satisfies ChartConfig;
+
+export function EChartsSvgRendererPieChart() {
+  return (
+    <EChartsPieChart
+      renderer="svg"
+      className="h-full w-full p-4"
+      data={data}
+      dataKey="visitors"
+      nameKey="browser"
+      config={chartConfig}
+    >
+      <EChartsPieChart.Legend isClickable />
+      <EChartsPieChart.Tooltip />
+      <EChartsPieChart.Pie isClickable />
+    </EChartsPieChart>
+  );
+}

--- a/src/registry/examples/echarts/ex-svg-renderer-echarts-radar-chart.tsx
+++ b/src/registry/examples/echarts/ex-svg-renderer-echarts-radar-chart.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { EChartsRadarChart, type ChartConfig } from "@/registry/charts/echarts-radar-chart";
+
+const data = [
+  { skill: "JavaScript", desktop: 186, mobile: 80 },
+  { skill: "TypeScript", desktop: 305, mobile: 200 },
+  { skill: "React", desktop: 237, mobile: 120 },
+  { skill: "Node.js", desktop: 173, mobile: 190 },
+  { skill: "CSS", desktop: 209, mobile: 130 },
+  { skill: "Python", desktop: 214, mobile: 140 },
+];
+
+const chartConfig = {
+  desktop: {
+    label: "Desktop",
+    colors: {
+      light: ["#3b82f6"],
+      dark: ["#60a5fa"],
+    },
+  },
+  mobile: {
+    label: "Mobile",
+    colors: {
+      light: ["#10b981"],
+      dark: ["#34d399"],
+    },
+  },
+} satisfies ChartConfig;
+
+export function EChartsSvgRendererRadarChart() {
+  return (
+    <EChartsRadarChart
+      renderer="svg"
+      data={data}
+      config={chartConfig}
+      className="h-full w-full p-4"
+    >
+      <EChartsRadarChart.PolarGrid />
+      <EChartsRadarChart.PolarAngleAxis dataKey="skill" />
+      <EChartsRadarChart.Legend isClickable />
+      <EChartsRadarChart.Tooltip />
+      <EChartsRadarChart.Radar dataKey="desktop" variant="filled" isClickable>
+        <EChartsRadarChart.Dot variant="colored-border" />
+        <EChartsRadarChart.ActiveDot variant="default" />
+      </EChartsRadarChart.Radar>
+      <EChartsRadarChart.Radar dataKey="mobile" variant="filled" isClickable>
+        <EChartsRadarChart.Dot variant="colored-border" />
+        <EChartsRadarChart.ActiveDot variant="default" />
+      </EChartsRadarChart.Radar>
+    </EChartsRadarChart>
+  );
+}

--- a/src/registry/examples/echarts/ex-svg-renderer-echarts-radar-chart.tsx
+++ b/src/registry/examples/echarts/ex-svg-renderer-echarts-radar-chart.tsx
@@ -31,7 +31,7 @@ const chartConfig = {
 export function EChartsSvgRendererRadarChart() {
   return (
     <EChartsRadarChart
-      renderer="svg"
+      renderer="svg" // [!code highlight]
       data={data}
       config={chartConfig}
       className="h-full w-full p-4"

--- a/src/registry/examples/echarts/ex-svg-renderer-echarts-radial-chart.tsx
+++ b/src/registry/examples/echarts/ex-svg-renderer-echarts-radial-chart.tsx
@@ -51,7 +51,7 @@ const chartConfig = {
 export function EChartsSvgRendererRadialChart() {
   return (
     <EChartsRadialChart
-      renderer="svg"
+      renderer="svg" // [!code highlight]
       className="h-full w-full p-4"
       data={data}
       nameKey="browser"

--- a/src/registry/examples/echarts/ex-svg-renderer-echarts-radial-chart.tsx
+++ b/src/registry/examples/echarts/ex-svg-renderer-echarts-radial-chart.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { EChartsRadialChart, type ChartConfig } from "@/registry/charts/echarts-radial-chart";
+
+const data = [
+  { browser: "chrome", visitors: 275 },
+  { browser: "safari", visitors: 200 },
+  { browser: "firefox", visitors: 187 },
+  { browser: "edge", visitors: 173 },
+  { browser: "other", visitors: 90 },
+];
+
+const chartConfig = {
+  chrome: {
+    label: "Chrome",
+    colors: {
+      light: ["#3b82f6"],
+      dark: ["#60a5fa"],
+    },
+  },
+  safari: {
+    label: "Safari",
+    colors: {
+      light: ["#10b981"],
+      dark: ["#34d399"],
+    },
+  },
+  firefox: {
+    label: "Firefox",
+    colors: {
+      light: ["#f59e0b"],
+      dark: ["#fbbf24"],
+    },
+  },
+  edge: {
+    label: "Edge",
+    colors: {
+      light: ["#8b5cf6"],
+      dark: ["#a78bfa"],
+    },
+  },
+  other: {
+    label: "Other",
+    colors: {
+      light: ["#6b7280"],
+      dark: ["#9ca3af"],
+    },
+  },
+} satisfies ChartConfig;
+
+export function EChartsSvgRendererRadialChart() {
+  return (
+    <EChartsRadialChart
+      renderer="svg"
+      className="h-full w-full p-4"
+      data={data}
+      nameKey="browser"
+      config={chartConfig}
+      variant="full"
+    >
+      <EChartsRadialChart.Legend isClickable />
+      <EChartsRadialChart.Tooltip />
+      <EChartsRadialChart.RadialBar dataKey="visitors" isClickable />
+    </EChartsRadialChart>
+  );
+}

--- a/src/registry/examples/echarts/ex-svg-renderer-echarts-sankey-chart.tsx
+++ b/src/registry/examples/echarts/ex-svg-renderer-echarts-sankey-chart.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import {
+  EChartsSankeyChart,
+  type SankeyData,
+  type ChartConfig,
+} from "@/registry/charts/echarts-sankey-chart";
+
+// Marketing funnel - user acquisition to conversions
+const data: SankeyData = {
+  nodes: [
+    { name: "Organic" },
+    { name: "PaidAds" },
+    { name: "Social" },
+    { name: "Landing" },
+    { name: "Product" },
+    { name: "Cart" },
+    { name: "Purchase" },
+    { name: "Bounced" },
+  ],
+  links: [
+    { source: 0, target: 3, value: 42000 },
+    { source: 1, target: 3, value: 28000 },
+    { source: 2, target: 3, value: 18000 },
+    { source: 3, target: 4, value: 52000 },
+    { source: 3, target: 7, value: 36000 },
+    { source: 4, target: 5, value: 31000 },
+    { source: 4, target: 7, value: 21000 },
+    { source: 5, target: 6, value: 24000 },
+    { source: 5, target: 7, value: 7000 },
+  ],
+};
+
+const chartConfig = {
+  Organic: {
+    label: "Organic Search",
+    colors: {
+      light: ["#059669"],
+      dark: ["#34d399"],
+    },
+  },
+  PaidAds: {
+    label: "Paid Ads",
+    colors: {
+      light: ["#dc2626"],
+      dark: ["#f87171"],
+    },
+  },
+  Social: {
+    label: "Social Media",
+    colors: {
+      light: ["#7c3aed"],
+      dark: ["#a78bfa"],
+    },
+  },
+  Landing: {
+    label: "Landing Page",
+    colors: {
+      light: ["#0891b2"],
+      dark: ["#22d3ee"],
+    },
+  },
+  Product: {
+    label: "Product Page",
+    colors: {
+      light: ["#2563eb"],
+      dark: ["#60a5fa"],
+    },
+  },
+  Cart: {
+    label: "Cart",
+    colors: {
+      light: ["#ea580c"],
+      dark: ["#fb923c"],
+    },
+  },
+  Purchase: {
+    label: "Purchase",
+    colors: {
+      light: ["#16a34a"],
+      dark: ["#4ade80"],
+    },
+  },
+  Bounced: {
+    label: "Bounced",
+    colors: {
+      light: ["#f43f5e"],
+      dark: ["#fb7185"],
+    },
+  },
+} satisfies ChartConfig;
+
+export function EChartsSvgRendererSankeyChart() {
+  return (
+    <EChartsSankeyChart
+      renderer="svg"
+      className="h-full w-full p-4"
+      data={data}
+      config={chartConfig}
+    >
+      <EChartsSankeyChart.Node isClickable>
+        <EChartsSankeyChart.NodeLabel position="outside" showValues />
+      </EChartsSankeyChart.Node>
+      <EChartsSankeyChart.Link variant="source" />
+      <EChartsSankeyChart.Tooltip />
+    </EChartsSankeyChart>
+  );
+}

--- a/src/registry/examples/echarts/ex-svg-renderer-echarts-sankey-chart.tsx
+++ b/src/registry/examples/echarts/ex-svg-renderer-echarts-sankey-chart.tsx
@@ -93,7 +93,7 @@ const chartConfig = {
 export function EChartsSvgRendererSankeyChart() {
   return (
     <EChartsSankeyChart
-      renderer="svg"
+      renderer="svg" // [!code highlight]
       className="h-full w-full p-4"
       data={data}
       config={chartConfig}

--- a/src/registry/registry-example.ts
+++ b/src/registry/registry-example.ts
@@ -25,6 +25,17 @@ export const examples: Registry["items"] = [
     ],
   },
   {
+    name: "ex-svg-renderer-echarts-area-chart",
+    registryDependencies: ["@evilcharts/echarts-area-chart"],
+    type: "registry:block",
+    files: [
+      {
+        path: "examples/echarts/ex-svg-renderer-echarts-area-chart.tsx",
+        type: "registry:block",
+      },
+    ],
+  },
+  {
     name: "ex-brush-echarts-area-chart",
     registryDependencies: ["@evilcharts/echarts-area-chart"],
     type: "registry:block",
@@ -263,6 +274,17 @@ export const examples: Registry["items"] = [
     files: [
       {
         path: "examples/echarts/ex-echarts-line-chart.tsx",
+        type: "registry:block",
+      },
+    ],
+  },
+  {
+    name: "ex-svg-renderer-echarts-line-chart",
+    registryDependencies: ["@evilcharts/echarts-line-chart"],
+    type: "registry:block",
+    files: [
+      {
+        path: "examples/echarts/ex-svg-renderer-echarts-line-chart.tsx",
         type: "registry:block",
       },
     ],
@@ -544,6 +566,17 @@ export const examples: Registry["items"] = [
     ],
   },
   {
+    name: "ex-svg-renderer-echarts-bar-chart",
+    registryDependencies: ["@evilcharts/echarts-bar-chart"],
+    type: "registry:block",
+    files: [
+      {
+        path: "examples/echarts/ex-svg-renderer-echarts-bar-chart.tsx",
+        type: "registry:block",
+      },
+    ],
+  },
+  {
     name: "ex-buffer-echarts-bar-chart",
     registryDependencies: ["@evilcharts/echarts-bar-chart"],
     type: "registry:block",
@@ -798,6 +831,17 @@ export const examples: Registry["items"] = [
     ],
   },
   {
+    name: "ex-svg-renderer-echarts-composed-chart",
+    registryDependencies: ["@evilcharts/echarts-composed-chart"],
+    type: "registry:block",
+    files: [
+      {
+        path: "examples/echarts/ex-svg-renderer-echarts-composed-chart.tsx",
+        type: "registry:block",
+      },
+    ],
+  },
+  {
     name: "ex-gradient-colors-echarts-composed-chart",
     registryDependencies: ["@evilcharts/echarts-composed-chart"],
     type: "registry:block",
@@ -942,6 +986,17 @@ export const examples: Registry["items"] = [
     ],
   },
   {
+    name: "ex-svg-renderer-echarts-radar-chart",
+    registryDependencies: ["@evilcharts/echarts-radar-chart"],
+    type: "registry:block",
+    files: [
+      {
+        path: "examples/echarts/ex-svg-renderer-echarts-radar-chart.tsx",
+        type: "registry:block",
+      },
+    ],
+  },
+  {
     name: "ex-lines-variant-echarts-radar-chart",
     registryDependencies: ["@evilcharts/echarts-radar-chart"],
     type: "registry:block",
@@ -993,6 +1048,17 @@ export const examples: Registry["items"] = [
     files: [
       {
         path: "examples/echarts/ex-echarts-pie-chart.tsx",
+        type: "registry:block",
+      },
+    ],
+  },
+  {
+    name: "ex-svg-renderer-echarts-pie-chart",
+    registryDependencies: ["@evilcharts/echarts-pie-chart"],
+    type: "registry:block",
+    files: [
+      {
+        path: "examples/echarts/ex-svg-renderer-echarts-pie-chart.tsx",
         type: "registry:block",
       },
     ],
@@ -1087,6 +1153,17 @@ export const examples: Registry["items"] = [
     ],
   },
   {
+    name: "ex-svg-renderer-echarts-radial-chart",
+    registryDependencies: ["@evilcharts/echarts-radial-chart"],
+    type: "registry:block",
+    files: [
+      {
+        path: "examples/echarts/ex-svg-renderer-echarts-radial-chart.tsx",
+        type: "registry:block",
+      },
+    ],
+  },
+  {
     name: "ex-semi-variant-echarts-radial-chart",
     registryDependencies: ["@evilcharts/echarts-radial-chart"],
     type: "registry:block",
@@ -1127,6 +1204,17 @@ export const examples: Registry["items"] = [
     files: [
       {
         path: "examples/echarts/ex-echarts-sankey-chart.tsx",
+        type: "registry:block",
+      },
+    ],
+  },
+  {
+    name: "ex-svg-renderer-echarts-sankey-chart",
+    registryDependencies: ["@evilcharts/echarts-sankey-chart"],
+    type: "registry:block",
+    files: [
+      {
+        path: "examples/echarts/ex-svg-renderer-echarts-sankey-chart.tsx",
         type: "registry:block",
       },
     ],

--- a/src/registry/registry-ui.ts
+++ b/src/registry/registry-ui.ts
@@ -77,7 +77,7 @@ export const ui: Registry["items"] = [
     ],
   },
 
-  // ── ECharts shared UI — the canvas counterparts of the recharts primitives.
+  // ── ECharts shared UI — the renderer-agnostic counterparts of the Recharts primitives.
   // Each ECharts chart pulls the modules it uses; nothing here touches recharts.
   {
     name: "echarts-chart",

--- a/src/registry/ui/echarts-chart.tsx
+++ b/src/registry/ui/echarts-chart.tsx
@@ -1,5 +1,19 @@
+import { CanvasRenderer, SVGRenderer } from "echarts/renderers";
 import type { ComponentType, ReactNode } from "react";
 import * as echarts from "echarts/core";
+
+export const ECHARTS_RENDERERS = {
+  canvas: "canvas",
+  svg: "svg",
+} as const;
+
+export type EChartsRenderer = (typeof ECHARTS_RENDERERS)[keyof typeof ECHARTS_RENDERERS];
+
+export const DEFAULT_ECHARTS_RENDERER = ECHARTS_RENDERERS.canvas;
+
+// Renderer registration is shared by every modular ECharts chart. Individual
+// chart modules only register the series and components they use.
+echarts.use([CanvasRenderer, SVGRenderer]);
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Theme keys + config — replicated from the repo's <ChartStyle> so the ECharts


### PR DESCRIPTION
## Summary

- add a shared Canvas/SVG renderer API to all eight ECharts chart roots, with Canvas remaining the default
- safely recreate chart instances when the renderer changes and reset renderer-owned interaction state
- add SVG renderer examples, documentation previews, and generated registry artifacts for every ECharts chart type
- highlight the `renderer="svg"` line in every example code preview
- document renderer-specific texture behavior for area, bar, and composed charts
- correct the radar chart composability copy identified during review

## Validation

- `bun run lint` (0 errors; 7 unrelated baseline warnings)
- `bunx tsc --noEmit --incremental false`
- `bun run registry:fresh` (279 registry items)
- `bun run build` (89 static pages)
- browser QA across all eight SVG previews: one SVG surface, zero canvases, and no runtime errors
- generated install payload audit: all eight SVG examples include the code-highlight marker
- verified all eight ECharts roots and their `main` counterparts pass the active `react-hooks/refs` rule with the pinned ESLint toolchain
